### PR TITLE
Fix progress page not updating

### DIFF
--- a/main.py
+++ b/main.py
@@ -366,8 +366,30 @@ def do_gn_ticket():
 
 @app.route("/progress/<session_id>")
 @require_auth
-def get_session_progress(session_id):
-    """Return progress updates for a given session ID."""
+def stream_session_progress(session_id):
+    """Stream progress updates for a given session ID using Server-Sent Events."""
+
+    def generate():
+        last_index = 0
+        while True:
+            progress = get_progress(session_id)
+            while last_index < len(progress):
+                entry = progress[last_index]
+                # Send each new entry as SSE data
+                yield f"data: {json.dumps(entry)}\n\n"
+                last_index += 1
+                # Stop streaming once the process is completed or an error occurs
+                if entry.get("status") in ("completed", "error"):
+                    return
+            time.sleep(1)
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+@app.route("/progress-status/<session_id>")
+@require_auth
+def get_session_progress_status(session_id):
+    """Return the full progress history for manual refresh."""
     return jsonify(get_progress(session_id))
 
 


### PR DESCRIPTION
## Summary
- Stream booking progress via Server-Sent Events
- Expose `/progress-status/<id>` endpoint for manual refresh

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf9f8622fc832ea19d39b54af602d9