### PR TITLE
Fix progress page not updating

### DIFF
--- a/gn_ticket.py
+++ b/gn_ticket.py
@@ -175,7 +175,7 @@ def gn_ticket_handler(book_sessions, username, pw, zoom_account, progress_sessio
                     'title': cn_session.title,
                     'ticket_id': ticket_result.get('ticket_id', 'Unknown')
                 })
-                set_progress(progress_session_id, f"✅ Completed {cn_session.title}", 8, 8, "running")
+                set_progress(progress_session_id, f"✅ Completed {cn_session.title}", 8, 8, "session-complete")
 
             except Exception as e:
                 error_msg = f"❌ Error processing {cn_session.title}: {str(e)}"
@@ -183,7 +183,7 @@ def gn_ticket_handler(book_sessions, username, pw, zoom_account, progress_sessio
                     'title': cn_session.title,
                     'error': str(e)
                 })
-                set_progress(progress_session_id, error_msg, 8, 8)
+                set_progress(progress_session_id, error_msg, 8, 8, "error session-complete")
                 print(f"Error processing {cn_session.title}: {repr(e)}")
 
         # Create detailed completion message

--- a/main.py
+++ b/main.py
@@ -366,8 +366,30 @@ def do_gn_ticket():
 
 @app.route("/progress/<session_id>")
 @require_auth
-def get_session_progress(session_id):
-    """Return progress updates for a given session ID."""
+def stream_session_progress(session_id):
+    """Stream progress updates for a given session ID using Server-Sent Events."""
+
+    def generate():
+        last_index = 0
+        while True:
+            progress = get_progress(session_id)
+            while last_index < len(progress):
+                entry = progress[last_index]
+                # Send each new entry as SSE data
+                yield f"data: {json.dumps(entry)}\n\n"
+                last_index += 1
+                # Stop streaming once the process is completed or an error occurs
+                if entry.get("status") in ("completed", "error"):
+                    return
+            time.sleep(1)
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+@app.route("/progress-status/<session_id>")
+@require_auth
+def get_session_progress_status(session_id):
+    """Return the full progress history for manual refresh."""
     return jsonify(get_progress(session_id))
 
 

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -49,9 +49,6 @@
     background: white;
     font-family: monospace;
     font-size: 14px;
-    display: flex;
-    /* --- FIX: STACK LOGS VERTICALLY, NEWEST ON TOP --- */
-    flex-direction: column-reverse;
 }
 
 .log-entry {
@@ -175,7 +172,7 @@
   </header>
   
   <div class="progress-container">
-    <h2>Processing {{ session_count }} session(s)...</h2>
+    <h2>Processing <span id="remainingSessions">{{ session_count }}</span> session(s)...</h2>
     
     <!-- Progress Bar -->
     <div class="progress-bar">
@@ -192,7 +189,7 @@
     <!-- Progress Log -->
     <h3>Progress Log:</h3>
     <div class="log-container" id="logContainer">
-      <!-- Initial entry will be at bottom (oldest) due to flex-direction: column-reverse -->
+      <!-- Initial entry will be at top; new events append below -->
       <div class="log-entry" id="initialEntry">
         <span class="timestamp">--:--:--</span>
         Initializing booking process...
@@ -209,6 +206,8 @@
 
 <script>
 const progressSessionId = "{{ progress_session_id }}";
+const sessionCount = {{ session_count }};
+let remainingSessions = sessionCount;
 let eventSource = null;
 let isComplete = false;
 
@@ -238,42 +237,43 @@ function startProgressStream() {
     };
 }
 
-function updateWithNewEntry(entry) {
+function updateWithNewEntry(entry, skipCountdown = false, skipLog = false) {
     const logContainer = document.getElementById('logContainer');
     const progressFill = document.getElementById('progressFill');
     const progressText = document.getElementById('progressText');
     const spinner = document.getElementById('spinner');
     const statusMessage = document.getElementById('statusMessage');
+    const remainingSpan = document.getElementById('remainingSessions');
 
-    // 1. Find the previously active log entry and deactivate it
-    const previousActive = logContainer.querySelector('.log-entry.active');
-    if (previousActive) {
-        previousActive.classList.remove('active');
-    }
+    if (!skipLog) {
+        // 1. Find the previously active log entry and deactivate it
+        const previousActive = logContainer.querySelector('.log-entry.active');
+        if (previousActive) {
+            previousActive.classList.remove('active');
+        }
 
-    // 2. Add new log entry
-    const logEntry = document.createElement('div');
-    logEntry.className = `log-entry ${entry.status}`;
-    logEntry.innerHTML = `
-        <span class="timestamp">${entry.timestamp}</span>
-        ${entry.message}
-    `;
+        // 2. Add new log entry
+        const logEntry = document.createElement('div');
+        logEntry.className = `log-entry ${entry.status}`;
+        logEntry.innerHTML = `
+            <span class="timestamp">${entry.timestamp}</span>
+            ${entry.message}
+        `;
 
-    // 3. Make the new entry the active one
-    logEntry.classList.add('active');
+        // 3. Make the new entry the active one
+        logEntry.classList.add('active');
 
-    // Append the new entry. Because of column-reverse, it appears at the top.
-    logContainer.appendChild(logEntry);
+        // Append the new entry at the bottom
+        logContainer.appendChild(logEntry);
 
-    // *** THE CRITICAL FIX IS HERE ***
-    // We must scroll to the BOTTOM of the container's content (scrollHeight)
-    // to make the newest item (which is visually at the top) visible.
-    logContainer.scrollTop = logContainer.scrollHeight;
+        // Keep the newest entry in view
+        logContainer.scrollTop = logContainer.scrollHeight;
 
-    // Remove the initial placeholder entry
-    const initialEntry = document.getElementById('initialEntry');
-    if (initialEntry) {
-        initialEntry.remove();
+        // Remove the initial placeholder entry
+        const initialEntry = document.getElementById('initialEntry');
+        if (initialEntry) {
+            initialEntry.remove();
+        }
     }
 
     // Update the top progress text and bar
@@ -286,15 +286,26 @@ function updateWithNewEntry(entry) {
         progressText.textContent = entry.message;
     }
 
-    // Handle completion or error state
-    if (entry.status === 'completed' || entry.status === 'error') {
+    // Update session countdown
+    if (!skipCountdown && entry.status && entry.status.includes('session-complete')) {
+        remainingSessions = Math.max(remainingSessions - 1, 0);
+        remainingSpan.textContent = remainingSessions;
+    }
+
+    // Handle completion or terminal error state
+    const isTerminalError = entry.status && entry.status.includes('error') && !entry.status.includes('session-complete');
+    const isCompleted = entry.status && entry.status.includes('completed');
+    if (isCompleted || isTerminalError) {
         isComplete = true;
         progressFill.style.width = '100%';
         spinner.style.display = 'none';
 
-        logEntry.classList.remove('active'); // Stop pulsing on the final item
+        const activeEntry = logContainer.querySelector('.log-entry.active');
+        if (activeEntry) {
+            activeEntry.classList.remove('active'); // Stop pulsing on the final item
+        }
 
-        if (entry.status === 'completed') {
+        if (isCompleted && !isTerminalError) {
             statusMessage.innerHTML = '<div class="status-complete">✓ Booking process completed successfully!</div>';
         } else {
             statusMessage.innerHTML = '<div class="status-error">✗ An error occurred during the booking process.</div>';
@@ -322,14 +333,21 @@ function refreshProgress() {
                 logContainer.appendChild(logEntry);
             });
 
+            // Recalculate remaining sessions
+            const completedCount = data.filter(e => e.status && e.status.includes('session-complete')).length;
+            remainingSessions = Math.max(sessionCount - completedCount, 0);
+            document.getElementById('remainingSessions').textContent = remainingSessions;
+
             // Mark the last entry as active if the process is not complete
             const lastEntryData = data[data.length - 1];
-            if (lastEntryData.status !== 'completed' && lastEntryData.status !== 'error') {
+            const lastIsTerminalError = lastEntryData.status && lastEntryData.status.includes('error') && !lastEntryData.status.includes('session-complete');
+            const lastIsCompleted = lastEntryData.status && lastEntryData.status.includes('completed');
+            if (!(lastIsCompleted || lastIsTerminalError)) {
                 logContainer.lastChild.classList.add('active');
             }
 
-            // Also update the top text with the latest message
-            updateWithNewEntry(lastEntryData);
+              // Also update progress bar and status message
+              updateWithNewEntry(lastEntryData, true, true);
         })
         .catch(error => {
             console.error('Error fetching progress:', error);


### PR DESCRIPTION
## Summary
- Stream booking progress via Server-Sent Events
- Expose `/progress-status/<id>` endpoint for manual refresh
- Count down remaining sessions as each completes
- Append progress log entries at bottom and keep view on latest update

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf9f8622fc832ea19d39b54af602d9