### PR TITLE
fix: correct debug reference

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ def load_config_from_env():
     is_valid = bool(config['GOOGLE_CLIENT_ID'] and config['GOOGLE_CLIENT_SECRET'])
     if not is_valid:
         logging.error("Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET environment variable.")
-        print(f"*** DEBUG: Loaded CONFIG = {CONFIG}")
+        print(f"*** DEBUG: Loaded CONFIG = {config}")
     return config, is_valid
 
 


### PR DESCRIPTION
## Summary
- fix debug print in load_config_from_env to reference local config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0cddd62a0832ea5d7915b47771372