### PR TITLE
Disable Flask debug mode for production

### DIFF
--- a/main.py
+++ b/main.py
@@ -495,4 +495,5 @@ def get_enabled_sessions(request):
 gn_ticket.set_progress_callback(set_progress)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    # Run the Flask app without debug mode when packaged for production
+    app.run(debug=False)


### PR DESCRIPTION
## Summary
- run Flask app without debug mode in main entrypoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cde6c4bc832e843e7644f36eb8a6