### PR TITLE
Fix pytz version to valid release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ requests>=2.31.0
 
 # Date/time handling
 python-dateutil>=2.8.2
-pytz>=2.3.0
+pytz>=2023.3
 
 # Cryptography for secure credential storage
 cryptography>=42.0.0


### PR DESCRIPTION
## Summary
- corrects `pytz` requirement to `>=2023.3`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cdfc6530832e97b1a3cf43472848