### PR TITLE
Add update progress API and page

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,6 +106,15 @@ progress_store = {}
 progress_counters = {}
 progress_lock = threading.Lock()
 
+# Simple global progress tracking for the updater
+update_progress = {
+    'progress': 0,
+    'message': 'Not started',
+    'complete': False,
+    'error': None
+}
+update_progress_lock = threading.Lock()
+
 
 def load_config_from_env():
     config = {
@@ -468,19 +477,50 @@ def install_update():
         if not update_info.get('available'):
             return jsonify({"success": False, "error": "No update available"})
 
+        with update_progress_lock:
+            update_progress.update({
+                'progress': 0,
+                'message': 'Starting update...',
+                'complete': False,
+                'error': None
+            })
+
         def run_update():
             try:
                 AppUpdater().prepare_and_launch_installer(update_info['download_url'])
+                with update_progress_lock:
+                    update_progress.update({
+                        'progress': 100,
+                        'message': 'Update launched',
+                        'complete': True
+                    })
             except Exception as e:
                 logging.error(f"Update preparation failed: {e}", exc_info=True)
+                with update_progress_lock:
+                    update_progress.update({
+                        'error': str(e),
+                        'message': f'Update failed: {e}',
+                        'complete': True
+                    })
 
         threading.Thread(target=run_update, daemon=True).start()
 
-        return """<html><body style="font-family: sans-serif; text-align: center; padding-top: 50px;">
-                    <h1>Update in Progress</h1><p>A native progress window has opened.</p>
-                    <p>You can close this browser window.</p></body></html>"""
+        return jsonify({"success": True})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
+
+
+@app.route("/update/install-page")
+@require_auth
+def update_install_page():
+    return render_template("update_progress.html")
+
+
+@app.route("/update/progress")
+@require_auth
+def get_update_progress():
+    with update_progress_lock:
+        return jsonify(update_progress)
 
 
 @app.route("/update/dismiss", methods=["POST"])

--- a/templates/update.html
+++ b/templates/update.html
@@ -239,7 +239,7 @@ function startUpdate() {
     .then(response => response.json())
     .then(data => {
         if (data.success) {
-            // Redirect to progress page
+            // After successfully starting the update, go to the progress page
             window.location.href = '/update/install-page';
         } else {
             alert('Update failed: ' + (data.error || 'Unknown error'));

--- a/templates/update_progress.html
+++ b/templates/update_progress.html
@@ -213,29 +213,6 @@
         let updateComplete = false;
         let hasError = false;
 
-        // Start the update process
-        function startUpdate() {
-            fetch('/update/install', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                }
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    console.log('Update started successfully');
-                    pollProgress();
-                } else {
-                    showError('Failed to start update: ' + (data.error || 'Unknown error'));
-                }
-            })
-            .catch(error => {
-                console.error('Error starting update:', error);
-                showError('Failed to start update: ' + error.message);
-            });
-        }
-
         // Poll for progress updates
         function pollProgress() {
             if (updateComplete) return;
@@ -337,10 +314,10 @@
             window.location.href = '/gn_ticket';
         }
 
-        // Start the update process when page loads
+        // Begin polling when the page loads
         window.addEventListener('load', function() {
             // Small delay to show the UI before starting
-            setTimeout(startUpdate, 1000);
+            setTimeout(pollProgress, 1000);
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Return JSON after starting an update and expose install progress via `/update/progress`
- Add `/update/install-page` that renders the progress view
- Adjust update templates to redirect to the progress page and poll only for progress

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c375e73c10832e849284369eca4f9e