### PR TITLE
Allow custom session buffer durations

### DIFF
--- a/templates/gn.html
+++ b/templates/gn.html
@@ -124,6 +124,17 @@ function removeSession(button) {
       </label>
     </div>
 
+    <div style="margin: 15px 0; padding: 10px; background: #f0f8ff; border-radius: 5px;">
+      <label style="margin-right: 10px;">
+        Minutes before:
+        <input type="number" name="buffer_before" id="buffer_before" value="{{ buffer_before }}" style="width: 60px;">
+      </label>
+      <label>
+        Minutes after:
+        <input type="number" name="buffer_after" id="buffer_after" value="{{ buffer_after }}" style="width: 60px;">
+      </label>
+    </div>
+
     <p>
       <input type="submit" name="book_sessions" id="book_sessions" value="Book displayed sessions with GN">
     </p>


### PR DESCRIPTION
## Summary
- Add before/after buffer minute inputs on session booking page
- Persist buffer choices per user and pass to GN ticket workflow
- Support customizable buffer times in GN ticket handler
- Pass buffer settings to GN ticket form to avoid undefined variable error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4bf95a1a4832e825e5b24eee932ad