### PR TITLE
Add logout option and match sessions by email

### DIFF
--- a/airtable_integration.py
+++ b/airtable_integration.py
@@ -144,13 +144,13 @@ class AirtableIntegration:
             "Content-Type": "application/json"
         }
 
-    def get_sessions(self, status_filters=None, user_name=None):
+    def get_sessions(self, status_filters=None, user_email=None):
         """
         Get sessions from Airtable with optional filtering
 
         Args:
             status_filters: List of status values to filter by (e.g., ["Booked", "Confirmed for Booking"])
-            user_name: Filter by user name (for School Lead field)
+            user_email: Filter by user email (for School Lead Email field)
 
         Returns:
             List of AirtableSession objects
@@ -170,9 +170,9 @@ class AirtableIntegration:
                 else:
                     filter_parts.append(f"OR({', '.join(status_conditions)})")
 
-            if user_name:
-                # UPDATED: Use School Lead Text instead of School Lead (which might be a linked record)
-                filter_parts.append(f"{{School Lead Text}} = '{user_name}'")
+            if user_email:
+                # Use School Lead Email for matching instead of name
+                filter_parts.append(f"{{School Lead Email}} = '{user_email}'")
 
                 # ADDED: Filter for Nunavut sessions only
                 filter_parts.append("FIND('NU', {School P/T}) > 0")
@@ -221,12 +221,12 @@ class AirtableIntegration:
                     status_value = first_record.get('fields', {}).get('Status', 'NOT FOUND')
                     school_pt = first_record.get('fields', {}).get('School P/T', 'NOT FOUND')
                     gn_ticket = first_record.get('fields', {}).get('GN Ticket ID', 'NOT FOUND')
-                    school_lead = first_record.get('fields', {}).get('School Lead Text', 'NOT FOUND')
+                    school_lead_email = first_record.get('fields', {}).get('School Lead Email', 'NOT FOUND')
                     gn_ticket_requested = first_record.get('fields', {}).get('GN Ticket Requested', 'NOT FOUND')
                     print(f"📋 Status field value: {status_value}")
                     print(f"📋 School P/T field value: {school_pt}")
                     print(f"📋 GN Ticket ID field value: {gn_ticket}")
-                    print(f"📋 School Lead Text field value: {school_lead}")
+                    print(f"📋 School Lead Email field value: {school_lead_email}")
                     print(f"📋 GN Ticket Requested field value: {gn_ticket_requested}")
 
                 # Convert records to session objects
@@ -249,14 +249,14 @@ class AirtableIntegration:
                     print(f"Response content: {e.response.text}")
                 raise Exception(f"Failed to fetch sessions from Airtable: {e}")
 
-        user_filter_msg = f" for user '{user_name}'" if user_name else ""
+        user_filter_msg = f" for user '{user_email}'" if user_email else ""
         print(f"✅ Found {len(sessions)} Nunavut sessions{user_filter_msg} that haven't been processed yet")
         return sessions
 
-    def get_booked_sessions(self, user_name=None):
+    def get_booked_sessions(self, user_email=None):
         """Get sessions with 'Booked' status"""
         # FIXED: Use the correct status value
-        return self.get_sessions(status_filters=["Booked"], user_name=user_name)
+        return self.get_sessions(status_filters=["Booked"], user_email=user_email)
 
     def update_session_field(self, session_id, field_name, value):
         """Update a specific field in a session record"""

--- a/main.py
+++ b/main.py
@@ -339,7 +339,7 @@ def gn_ticket_page():
                                current_version=session.get('current_version'), user=user, auto_detected=True)
 
     try:
-        sessions_data = create_airtable_client(profile['airtable_api_key']).get_booked_sessions(user_name=user['name'])
+        sessions_data = create_airtable_client(profile['airtable_api_key']).get_booked_sessions(user_email=user['email'])
         session['book_sessions'] = sessions_data
 
         prefs = profile.get('preferences', {})

--- a/templates/gn.html
+++ b/templates/gn.html
@@ -95,6 +95,10 @@ function removeSession(button) {
 <!-- Header -->
 <header class="header content-wrapper">
   <h4 class="logo">Make my Zoom &amp; GN tickets</h4>
+  <div style="text-align: center; padding: 10px;">
+    <span style="color: white;">{{ user.name }}</span>
+    <a href="/logout" style="color: white; margin-left: 20px;">Logout</a>
+  </div>
 </header>
 
 <!-- Update available banner -->

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -168,6 +168,10 @@
   <!-- Header -->
   <header class="header">
     <h4 class="logo">GN Ticket Booking Progress</h4>
+    <div style="text-align: center; padding: 10px;">
+      <span style="color: white;">{{ user.name }}</span>
+      <a href="/logout" style="color: white; margin-left: 20px;">Logout</a>
+    </div>
   </header>
   
   <div class="progress-container">

--- a/templates/setup_profile.html
+++ b/templates/setup_profile.html
@@ -266,6 +266,10 @@
 <div class="container">
   <header class="header">
     <h4 class="logo">Profile Setup - GN Ticket Automator</h4>
+    <div style="text-align: center; padding: 10px;">
+      <span style="color: white;">{{ user.name }}</span>
+      <a href="/logout" style="color: white; margin-left: 20px;">Logout</a>
+    </div>
   </header>
   
   <div class="setup-container">

--- a/templates/update.html
+++ b/templates/update.html
@@ -150,6 +150,10 @@
 <div class="container">
     <header class="header">
         <h4 class="logo">GN Ticket Automator - Update Available</h4>
+        <div style="text-align: center; padding: 10px;">
+            <span style="color: white;">{{ user.name }}</span>
+            <a href="/logout" style="color: white; margin-left: 20px;">Logout</a>
+        </div>
     </header>
     
     <div class="update-container">


### PR DESCRIPTION
## Summary
- Filter Airtable sessions using the user's email instead of display name for reliable matching
- Add logout links to session, profile, update, and progress pages to allow switching Google accounts

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4c8ba684c832e82bb87249863970d