### PR TITLE
Move site matching off gpt-3.5-turbo and make the model configurable

### DIFF
--- a/gn_ticket.py
+++ b/gn_ticket.py
@@ -479,25 +479,49 @@ def get_all_dropdown_options_from_html(driver, element_id_to_click, results_css_
         return []
 
 
-def ask_chatgpt_for_best_match(dropdown_options, community_name, school_name, api_key=None):
+# The site matcher's model, overridable without a code change — OpenAI retires models
+# on a schedule (gpt-3.5-turbo shuts down 2026-10-23), and a hardcoded ID is how that
+# becomes an outage. Confirm the current ID against OpenAI's model list before changing.
+CHATGPT_MODEL = os.getenv("CHATGPT_MODEL", "gpt-5-mini")
+CHATGPT_TIMEOUT = int(os.getenv("CHATGPT_TIMEOUT", "30"))
+
+
+def _chat_completion_payload(model, prompt, max_output_tokens=100):
+    """Build a request body valid for the given model family.
+
+    The GPT-5 family rejects `temperature` outright and renamed `max_tokens` to
+    `max_completion_tokens`, so a bare model-string swap from a GPT-4-era model
+    returns 400. Branching here keeps CHATGPT_MODEL genuinely swappable.
     """
-    Ask ChatGPT to select the best matching site from dropdown options
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
 
-    Args:
-        dropdown_options: List of available site options from dropdown
-        community_name: Community name from Airtable
-        school_name: School name from Airtable
-        api_key: OpenAI API key
+    if model.startswith("gpt-5") or model.startswith("o1") or model.startswith("o3"):
+        payload["max_completion_tokens"] = max_output_tokens
+    else:
+        payload["max_tokens"] = max_output_tokens
+        # Near-deterministic: this is a lookup, not a creative task.
+        payload["temperature"] = 0.1
 
-    Returns:
-        Best matching option or None
+    return payload
+
+
+def ask_chatgpt_for_best_match(dropdown_options, community_name, school_name, api_key=None):
+    """Pick the ServiceNow site that matches a school, when string matching could not.
+
+    This is a fallback behind basic_site_match(). Every answer is checked against the
+    options actually offered, so a wrong or invented answer is discarded rather than
+    submitted — the caller falls back to manual site selection.
+
+    Returns the exact option text, or None.
     """
     if not dropdown_options or not api_key:
-        set_progress_func(None, f"DEBUG SITE: ChatGPT skipped (no options or API key).", None, None)
+        set_progress_func(None, "DEBUG SITE: Site matching by model skipped (no options or API key).", None, None)
         return None
 
-    # Prepare the prompt for ChatGPT
-    prompt = f"""You are helping to match a school location to the correct ServiceNow site entry. 
+    prompt = f"""You are helping to match a school location to the correct ServiceNow site entry.
 
 School Information:
 - Community: {community_name}
@@ -508,54 +532,48 @@ Available Site Options from ServiceNow dropdown:
 
 Please select the EXACT text of the most appropriate site option from the list above that best matches this school location. Consider:
 1. Community name matching
-2. School name matching  
+2. School name matching
 3. Geographic proximity
 4. Common abbreviations or variations
 
 Respond with ONLY the exact text of your chosen option, nothing else."""
 
     try:
-        headers = {
-            'Authorization': f'Bearer {api_key}',
-            'Content-Type': 'application/json'
-        }
+        response = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=_chat_completion_payload(CHATGPT_MODEL, prompt),
+            timeout=CHATGPT_TIMEOUT,
+        )
 
-        data = {
-            'model': 'gpt-3.5-turbo',
-            'messages': [
-                {'role': 'user', 'content': prompt}
-            ],
-            'max_tokens': 100,
-            'temperature': 0.1
-        }
-
-        response = requests.post('https://api.openai.com/v1/chat/completions',
-                                 headers=headers, json=data, timeout=30)
-
-        if response.status_code == 200:
-            result = response.json()
-            suggested_match = result['choices'][0]['message']['content'].strip()
-
-            # Verify the suggestion is actually in our options
-            for option in dropdown_options:
-                if option.strip().lower() == suggested_match.lower():
-                    set_progress_func(None, f"DEBUG SITE: ChatGPT suggested valid option: '{option}'.", None, None)
-                    return option
-
-            set_progress_func(None,
-                              f"DEBUG SITE: ChatGPT suggested '{suggested_match}' but it's not in available options.",
-                              None, None, "warning")
-            print(f"ChatGPT suggested '{suggested_match}' but it's not in available options")
+        if response.status_code != 200:
+            # Logged, not just printed: on the scheduled run nobody is watching stdout,
+            # and a retired model ID surfaces here as a 404 rather than as bad matching.
+            logging.warning("Site matching model %s returned HTTP %s: %s",
+                            CHATGPT_MODEL, response.status_code, response.text[:300])
+            set_progress_func(None, f"DEBUG SITE: Site matching API error: {response.status_code}",
+                              None, None, "error")
             return None
-        else:
-            set_progress_func(None, f"DEBUG SITE: ChatGPT API error: {response.status_code} - {response.text}", None,
-                              None, "error")
-            print(f"ChatGPT API error: {response.status_code}")
-            return None
+
+        suggested_match = response.json()["choices"][0]["message"]["content"].strip()
+
+        for option in dropdown_options:
+            if option.strip().lower() == suggested_match.lower():
+                set_progress_func(None, f"DEBUG SITE: Model suggested valid option: '{option}'.", None, None)
+                return option
+
+        logging.info("Site matching model suggested %r, which is not an available option.", suggested_match)
+        set_progress_func(None,
+                          f"DEBUG SITE: Model suggested '{suggested_match}' but it's not in available options.",
+                          None, None, "warning")
+        return None
 
     except Exception as e:
-        set_progress_func(None, f"DEBUG SITE: Error calling ChatGPT API: {e}", None, None, "error")
-        print(f"Error calling ChatGPT API: {e}")
+        logging.warning("Site matching call failed: %s", e, exc_info=True)
+        set_progress_func(None, f"DEBUG SITE: Error calling site matching API: {e}", None, None, "error")
         return None
 
 

--- a/render.yaml
+++ b/render.yaml
@@ -33,6 +33,9 @@ envVarGroups:
         sync: false
       - key: CHATGPT_API_KEY
         sync: false
+      # Optional. Overridable so a model retirement is a dashboard edit, not a deploy.
+      - key: CHATGPT_MODEL
+        value: gpt-5-mini
 
 services:
   - type: web

--- a/tests/test_site_match_llm.py
+++ b/tests/test_site_match_llm.py
@@ -1,0 +1,128 @@
+"""The LLM site-match fallback.
+
+This runs only when basic_site_match() fails, and whatever it returns is checked
+against the options ServiceNow actually offered — so the property that matters is
+that a wrong, invented, or unavailable answer becomes None rather than a bad ticket.
+"""
+import gn_ticket
+
+
+OPTIONS = ["Iqaluit Nakasuk School", "Rankin Inlet Maani Ulujuk School", "Igloolik High School, Desktop Unit"]
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, content=None, text=""):
+        self.status_code = status_code
+        self._content = content
+        self.text = text
+
+    def json(self):
+        return {"choices": [{"message": {"content": self._content}}]}
+
+
+def _capture(monkeypatch, response):
+    """Swap the HTTP call for a recorder, returning the captured request body."""
+    sent = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        sent["url"] = url
+        sent["headers"] = headers
+        sent["json"] = json
+        sent["timeout"] = timeout
+        return response
+
+    monkeypatch.setattr(gn_ticket.requests, "post", fake_post)
+    return sent
+
+
+def test_a_valid_suggestion_is_returned(monkeypatch):
+    _capture(monkeypatch, FakeResponse(content="Iqaluit Nakasuk School"))
+
+    result = gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert result == "Iqaluit Nakasuk School"
+
+
+def test_matching_ignores_case_and_padding(monkeypatch):
+    _capture(monkeypatch, FakeResponse(content="  iqaluit nakasuk school  "))
+
+    result = gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert result == "Iqaluit Nakasuk School"
+
+
+def test_an_invented_option_is_rejected(monkeypatch):
+    """The safety property: never return something ServiceNow did not offer."""
+    _capture(monkeypatch, FakeResponse(content="Some School That Does Not Exist"))
+
+    result = gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert result is None
+
+
+def test_an_api_error_returns_none(monkeypatch):
+    """A retired model ID lands here as a 404 — it must not raise into the booking loop."""
+    _capture(monkeypatch, FakeResponse(status_code=404, text="model not found"))
+
+    result = gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert result is None
+
+
+def test_a_network_failure_returns_none(monkeypatch):
+    def boom(*args, **kwargs):
+        raise ConnectionError("network down")
+
+    monkeypatch.setattr(gn_ticket.requests, "post", boom)
+
+    result = gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert result is None
+
+
+def test_no_api_key_skips_the_call(monkeypatch):
+    def fail(*args, **kwargs):
+        raise AssertionError("must not call the API without a key")
+
+    monkeypatch.setattr(gn_ticket.requests, "post", fail)
+
+    assert gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key=None) is None
+    assert gn_ticket.ask_chatgpt_for_best_match([], "Iqaluit", "Nakasuk School", api_key="sk-test") is None
+
+
+def test_gpt5_family_payload_omits_temperature(monkeypatch):
+    """GPT-5 rejects temperature and renamed max_tokens; a bare string swap would 400."""
+    monkeypatch.setattr(gn_ticket, "CHATGPT_MODEL", "gpt-5-mini")
+    sent = _capture(monkeypatch, FakeResponse(content="Iqaluit Nakasuk School"))
+
+    gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert sent["json"]["model"] == "gpt-5-mini"
+    assert sent["json"]["max_completion_tokens"] == 100
+    assert "max_tokens" not in sent["json"]
+    assert "temperature" not in sent["json"]
+
+
+def test_earlier_models_keep_the_legacy_payload(monkeypatch):
+    monkeypatch.setattr(gn_ticket, "CHATGPT_MODEL", "gpt-4o-mini")
+    sent = _capture(monkeypatch, FakeResponse(content="Iqaluit Nakasuk School"))
+
+    gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    assert sent["json"]["model"] == "gpt-4o-mini"
+    assert sent["json"]["max_tokens"] == 100
+    assert sent["json"]["temperature"] == 0.1
+    assert "max_completion_tokens" not in sent["json"]
+
+
+def test_the_school_and_options_reach_the_prompt(monkeypatch):
+    sent = _capture(monkeypatch, FakeResponse(content="Iqaluit Nakasuk School"))
+
+    gn_ticket.ask_chatgpt_for_best_match(OPTIONS, "Iqaluit", "Nakasuk School", api_key="sk-test")
+
+    prompt = sent["json"]["messages"][0]["content"]
+    assert "Nakasuk School" in prompt
+    assert "Iqaluit" in prompt
+    for option in OPTIONS:
+        assert option in prompt
+    assert sent["headers"]["Authorization"] == "Bearer sk-test"


### PR DESCRIPTION
gpt-3.5-turbo shuts down on 2026-10-23. The site matcher pinned it in code, and its failure path is silent — errors are caught and the caller falls back to manual site selection — so the retirement would have surfaced as matching quietly getting worse rather than as anything anyone would notice.

- CHATGPT_MODEL environment variable, defaulting to gpt-5-mini, so the next retirement is a dashboard edit rather than a deploy. CHATGPT_TIMEOUT too.
- The GPT-5 family rejects `temperature` and renamed `max_tokens` to `max_completion_tokens`, so swapping only the model string would have returned 400 on every call. The request body is now built per model family, which is what makes the env var actually swappable in both directions.
- API errors and rejected suggestions now go through logging as well as the progress callback. On the scheduled run nobody reads stdout, and a retired model ID arrives here as a 404 that was previously invisible.

Behaviour is otherwise unchanged: this still runs only when basic_site_match fails, and every answer is still checked against the options ServiceNow offered, so an invented or unavailable answer is discarded rather than submitted.

Adds the first tests for this function: valid match, case and padding tolerance, invented-option rejection, HTTP error, network failure, missing key, and the payload shape for both model families. 54 pass.


Claude-Session: https://claude.ai/code/session_01P6rNwuLsc4BKY568h6Q8sQ