### PR TITLE
Cut Chrome's memory footprint to fit a 512 MB instance

### DIFF
--- a/gn_ticket.py
+++ b/gn_ticket.py
@@ -81,6 +81,89 @@ def generate_totp_token(secret):
         raise
 
 
+def _env_flag(name, default):
+    return os.getenv(name, str(default)).strip().lower() in ("1", "true", "yes")
+
+
+def build_chrome_options(headless_mode=True):
+    """Chrome options tuned to survive a small container.
+
+    Headless Chrome loading a heavy enterprise page is by far the largest thing this
+    process does, and on a 512 MB instance it is what gets the container OOM-killed.
+    The savings here, roughly in order of size:
+
+      * viewport — raster buffers scale with area, so 1280x720 costs under half of
+        1920x1080 and nothing in this flow depends on the larger canvas;
+      * images — the ticket form is filled by locator, never looked at, so decoded
+        bitmaps are pure overhead;
+      * V8 heap ceiling — caps the JS heap, so a runaway page fails as a renderer
+        error we can see instead of taking the whole container down with it;
+      * background subsystems — sync, translate, metrics, crash reporting and
+        component updates all allocate and none are wanted here.
+
+    Every lever is environment-tunable so a too-tight setting is a dashboard edit
+    rather than a redeploy.
+    """
+    options = webdriver.ChromeOptions()
+
+    if headless_mode:
+        options.add_argument("--headless")
+
+    # Required in a container.
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+
+    options.add_argument(f"--window-size={os.getenv('CHROME_WINDOW_SIZE', '1280,720')}")
+
+    if headless_mode and _env_flag("CHROME_DISABLE_IMAGES", True):
+        options.add_argument("--blink-settings=imagesEnabled=false")
+
+    js_heap_mb = os.getenv("CHROME_JS_HEAP_MB", "256").strip()
+    if js_heap_mb and js_heap_mb != "0":
+        options.add_argument(f"--js-flags=--max-old-space-size={js_heap_mb}")
+
+    # Caches buy nothing across a single short run and cost resident memory.
+    options.add_argument("--disk-cache-size=1")
+    options.add_argument("--media-cache-size=1")
+    options.add_argument("--renderer-process-limit=1")
+
+    for flag in (
+        "--disable-extensions",
+        "--disable-plugins",
+        "--disable-background-networking",
+        "--disable-component-update",
+        "--disable-client-side-phishing-detection",
+        "--disable-sync",
+        "--disable-translate",
+        "--disable-default-apps",
+        "--disable-domain-reliability",
+        "--disable-breakpad",
+        "--disable-hang-monitor",
+        "--disable-prompt-on-repost",
+        "--metrics-recording-only",
+        "--mute-audio",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ):
+        options.add_argument(flag)
+
+    # Last resort: runs the renderer inside the browser process, saving the per-process
+    # overhead at the cost of stability. Off by default — Chrome does not support it.
+    if _env_flag("CHROME_SINGLE_PROCESS", False):
+        options.add_argument("--single-process")
+
+    options.add_argument("--log-level=3")
+    options.add_experimental_option("excludeSwitches", ["enable-logging"])
+    options.add_experimental_option("useAutomationExtension", False)
+
+    options.add_argument(
+        "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+
+    return options
+
+
 def gn_ticket_handler(book_sessions, username, pw, zoom_account, progress_session_id=None, airtable_api_key=None,
                       totp_secret=None, headless_mode=True, chatgpt_api_key=None, allow_manual_site_selection=False,
                       buffer_before=10, buffer_after=10):
@@ -112,32 +195,8 @@ def gn_ticket_handler(book_sessions, username, pw, zoom_account, progress_sessio
     browser_mode_msg = "headless mode" if headless_mode else "visible browser mode"
     set_progress(progress_session_id, f"Setting up Chrome browser in {browser_mode_msg}...", 1, 8)
 
-    # Set up Chrome options
-    options = webdriver.ChromeOptions()
+    options = build_chrome_options(headless_mode)
 
-    if headless_mode:
-        # Enable headless mode
-        options.add_argument("--headless")
-
-    # Recommended options for better stability (apply regardless of headless mode)
-    options.add_argument("--no-sandbox")
-    options.add_argument("--disable-dev-shm-usage")
-    options.add_argument("--disable-gpu")
-    options.add_argument("--window-size=1920,1080")
-    options.add_argument("--disable-extensions")
-    options.add_argument("--disable-plugins")
-
-    # Optional: Reduce logging noise
-    options.add_argument("--log-level=3")
-    options.add_experimental_option('excludeSwitches', ['enable-logging'])
-    options.add_experimental_option('useAutomationExtension', False)
-
-    # Optional: Set user agent to avoid detection
-    options.add_argument(
-        "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
-
-    # In a container the browser and driver are installed at fixed paths; locally these
-    # are unset and Selenium Manager resolves them itself.
     chrome_binary = os.getenv("CHROME_BINARY")
     if chrome_binary:
         options.binary_location = chrome_binary

--- a/tests/test_chrome_options.py
+++ b/tests/test_chrome_options.py
@@ -1,0 +1,78 @@
+"""Chrome's launch flags.
+
+Headless Chrome is the largest allocation in the booking path, and on a 512 MB
+instance it is what gets the container OOM-killed. These pin the memory-relevant
+flags so a future edit cannot quietly drop one.
+"""
+import pytest
+
+from gn_ticket import build_chrome_options
+
+
+def args(**env):
+    return build_chrome_options(headless_mode=env.pop("headless", True)).arguments
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for name in ("CHROME_WINDOW_SIZE", "CHROME_DISABLE_IMAGES",
+                 "CHROME_JS_HEAP_MB", "CHROME_SINGLE_PROCESS"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_the_viewport_is_small_by_default():
+    """Raster memory scales with area; 1920x1080 costs more than twice 1280x720."""
+    assert "--window-size=1280,720" in args()
+
+
+def test_images_are_off_when_headless():
+    assert "--blink-settings=imagesEnabled=false" in args()
+
+
+def test_images_stay_on_when_watching_the_browser():
+    """'Watch it work' is useless if the page renders blank."""
+    assert "--blink-settings=imagesEnabled=false" not in args(headless=False)
+
+
+def test_the_js_heap_is_capped():
+    """A runaway page should fail as a renderer error, not take the container down."""
+    assert "--js-flags=--max-old-space-size=256" in args()
+
+
+def test_container_required_flags_are_present():
+    flags = args()
+    assert "--no-sandbox" in flags
+    assert "--disable-dev-shm-usage" in flags
+    assert "--headless" in flags
+
+
+def test_caches_and_background_work_are_disabled():
+    flags = args()
+    for flag in ("--disk-cache-size=1", "--media-cache-size=1",
+                 "--disable-background-networking", "--disable-sync",
+                 "--disable-component-update", "--metrics-recording-only"):
+        assert flag in flags
+
+
+def test_single_process_is_off_unless_asked_for(monkeypatch):
+    assert "--single-process" not in args()
+
+    monkeypatch.setenv("CHROME_SINGLE_PROCESS", "1")
+    assert "--single-process" in args()
+
+
+def test_every_lever_is_tunable_without_a_deploy(monkeypatch):
+    monkeypatch.setenv("CHROME_WINDOW_SIZE", "1024,768")
+    monkeypatch.setenv("CHROME_JS_HEAP_MB", "192")
+    monkeypatch.setenv("CHROME_DISABLE_IMAGES", "false")
+
+    flags = args()
+    assert "--window-size=1024,768" in flags
+    assert "--js-flags=--max-old-space-size=192" in flags
+    assert "--blink-settings=imagesEnabled=false" not in flags
+
+
+def test_the_heap_cap_can_be_removed(monkeypatch):
+    monkeypatch.setenv("CHROME_JS_HEAP_MB", "0")
+
+    assert not any(f.startswith("--js-flags") for f in args())


### PR DESCRIPTION
## The problem

The web service is being OOM-killed during booking, before the first session's Zoom check. That places it at Chrome starting up and loading ServiceNow — by far the largest allocation this process makes.

The spike is fast enough that Render's 15-second metric polling misses it entirely: the memory graph shows a flat ~20% (the Python app, roughly 100 MB of the 512 MB limit) and then a restart, with nothing in between.

Raising the instance to 2 GB costs +$18/month, which is more than this workload is worth.

## What changed

Chrome's flags now come from `build_chrome_options()`, with the memory levers turned down. Roughly in order of expected saving:

- **Viewport 1920x1080 → 1280x720.** Raster buffers scale with area, so this is under half the pixels. Nothing in the flow depends on the larger canvas — every element is reached by locator, never by coordinate.
- **Images off when headless.** The ticket form is filled, never looked at, so decoded bitmaps are pure overhead on a page that carries plenty of them. Left on when the browser is visible, or "watch it work" renders blank.
- **V8 heap capped at 256 MB.** This changes the failure mode as much as the footprint: a runaway page becomes a readable renderer error instead of an OOM kill that takes the container with it.
- **Caches pinned to nothing**, and sync, translate, metrics, crash reporting, component updates and background networking disabled. None are wanted for a single short automated run.
- **`--single-process`** available behind `CHROME_SINGLE_PROCESS`, off by default. It saves the per-process overhead but Chrome does not support the mode and complex pages can crash it — a last resort, not a default.

## Tuning without a deploy

Every lever reads from the environment, so tightening or backing one out is a dashboard edit:

| Variable | Default |
|---|---|
| `CHROME_WINDOW_SIZE` | `1280,720` |
| `CHROME_DISABLE_IMAGES` | `true` |
| `CHROME_JS_HEAP_MB` | `256` (`0` disables the cap) |
| `CHROME_SINGLE_PROCESS` | `false` |

If it is still tight, `1024,768` and a `192` MB heap are the next steps before anything structural.

## Tests

Nine new tests pin the memory-relevant flags so a later edit cannot quietly drop one, and cover both the defaults and each environment override. 69 passing overall. No CI in this repository, so that is a local result.

## What is not verified

The effect on real memory is unmeasured. The environment this was written in has neither Chrome nor a Docker daemon, so these are the right levers and the direction is certain, but whether they clear a real ServiceNow page under 512 MB needs confirming against the live service.

If they do not, the structural fix is to stop running Chrome in the web service at all and let the existing 2 GB cron job do the browser work on demand — it already does exactly this job nightly and bills per minute. That is a larger change than it first appears: progress is currently held in an in-memory dict (`main.py:115`) and streamed over SSE from the same process, so moving the work to another container means persisting progress to Postgres first. Worth doing only if these flags fall short.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P6rNwuLsc4BKY568h6Q8sQ)_