### PR TITLE
Collapse Chrome's per-origin renderer processes

### DIFF
--- a/gn_ticket.py
+++ b/gn_ticket.py
@@ -128,6 +128,16 @@ def build_chrome_options(headless_mode=True):
     options.add_argument("--media-cache-size=1")
     options.add_argument("--renderer-process-limit=1")
 
+    # Site isolation gives every origin its own renderer process, each with its own
+    # fixed overhead. That is a security boundary against hostile pages; here the
+    # browser visits exactly one trusted site under our own control, so the processes
+    # cost memory and protect against nothing. Collapsing them is the larger win on a
+    # page that pulls in several origins, and unlike --single-process it is a supported
+    # configuration.
+    if _env_flag("CHROME_DISABLE_SITE_ISOLATION", True):
+        options.add_argument("--disable-features=IsolateOrigins,site-per-process")
+        options.add_argument("--disable-site-isolation-trials")
+
     for flag in (
         "--disable-extensions",
         "--disable-plugins",

--- a/tests/test_chrome_options.py
+++ b/tests/test_chrome_options.py
@@ -16,7 +16,8 @@ def args(**env):
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
     for name in ("CHROME_WINDOW_SIZE", "CHROME_DISABLE_IMAGES",
-                 "CHROME_JS_HEAP_MB", "CHROME_SINGLE_PROCESS"):
+                 "CHROME_JS_HEAP_MB", "CHROME_SINGLE_PROCESS",
+                 "CHROME_DISABLE_SITE_ISOLATION"):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -76,3 +77,20 @@ def test_the_heap_cap_can_be_removed(monkeypatch):
     monkeypatch.setenv("CHROME_JS_HEAP_MB", "0")
 
     assert not any(f.startswith("--js-flags") for f in args())
+
+
+def test_site_isolation_is_off_by_default():
+    """Each isolated origin is its own renderer process; the browser visits one
+    trusted site, so those processes cost memory and guard against nothing."""
+    flags = args()
+
+    assert "--disable-features=IsolateOrigins,site-per-process" in flags
+    assert "--disable-site-isolation-trials" in flags
+
+
+def test_site_isolation_can_be_restored(monkeypatch):
+    monkeypatch.setenv("CHROME_DISABLE_SITE_ISOLATION", "false")
+    flags = args()
+
+    assert "--disable-features=IsolateOrigins,site-per-process" not in flags
+    assert "--disable-site-isolation-trials" not in flags


### PR DESCRIPTION
Follow-up to #34, which was not enough on its own.

## Where it is dying

With #34 deployed, booking still OOM-killed the 512 MB web instance. The log ends at:

```
Generated 2FA token: 418240
==> Instance srv-... restarted
```

That puts the peak at ServiceNow's **authenticated page loading**, not at Chrome startup — Chrome launched, reached the site, and entered credentials before the container went down.

## What this changes

Site isolation gives every origin its own renderer process, each carrying its own fixed overhead, so a page pulling in several origins pays that cost several times over. It exists as a security boundary against hostile pages. This browser visits exactly one trusted site under our own control, for a few minutes, with no user browsing — the isolation guards against nothing in this threat model while costing memory the instance does not have.

```
--disable-features=IsolateOrigins,site-per-process
--disable-site-isolation-trials
```

Unlike `--single-process` — already available here behind `CHROME_SINGLE_PROCESS` — this is a configuration Chrome supports. `--single-process` remains off by default because Chrome does not support it and complex pages can crash it.

Controlled by `CHROME_DISABLE_SITE_ISOLATION`, on by default, so it can be restored from the dashboard if a page turns out to depend on the isolated processes.

## Tests

Two more, covering the default and the override. 71 passing. No CI here, so that is a local result.

## If this is not enough

Still unmeasured — no Chrome and no Docker daemon in the environment this was written in.

If it falls short, the next step should be structural rather than another flag. The 2 GB cron container already runs this exact booking code nightly and bills per minute, so it is the natural home for the browser work. The cost is that progress is currently held in an in-memory dict (`main.py:115`) and streamed over SSE from the same process, so it has to move to Postgres before booking can run in a different container.

Worth noting meanwhile: **automated booking already works.** Only the dashboard's manual button is affected, and `gn-ticket-scan` can be triggered on demand from the Render dashboard today as a workaround, with no code change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P6rNwuLsc4BKY568h6Q8sQ)_