### PR TITLE
Look-ahead slider, sticky removals, last-minute holdback, manual-booking emails

### DIFF
--- a/conflict.py
+++ b/conflict.py
@@ -1,19 +1,34 @@
-from datetime import timedelta
+import os
+from datetime import datetime, timedelta, timezone
 from ticket_submission_log import parse_log_start_and_end
 
 
-def check_for_time_conflicts(candidate_sessions, existing_sessions, historical_ticket_entries=None):
+# A ticket filed this close to the session is not something the GN can act on, so
+# filing it is noise rather than a request. These are held back like a conflict and
+# reported to the person, who can still book by hand if it is genuinely worth it.
+LAST_MINUTE_HOURS = int(os.getenv("GN_LAST_MINUTE_HOURS", "12"))
+
+
+def check_for_time_conflicts(candidate_sessions, existing_sessions, historical_ticket_entries=None,
+                             now=None, last_minute_hours=None):
     """
     Checks for conflicts between candidate sessions (new GN ticket requests)
     and previously existing Airtable sessions for the same school.
 
-    Two scenarios are considered:
-    1. Time conflicts against already booked sessions that already have GN tickets.
-    2. Candidate sessions that are booked (but no GN ticket yet) and overlap in time.
+    Three scenarios are considered:
+    1. Sessions starting too soon for the GN to act on the request.
+    2. Time conflicts against already booked sessions that already have GN tickets.
+    3. Candidate sessions that are booked (but no GN ticket yet) and overlap in time.
     """
 
     candidate_ids = {session.s_id for session in candidate_sessions}
     historical_ticket_entries = historical_ticket_entries or []
+
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    hours = LAST_MINUTE_HOURS if last_minute_hours is None else last_minute_hours
+    last_minute_cutoff = now + timedelta(hours=hours)
 
     for candidate in candidate_sessions:
         candidate.is_conflict = False
@@ -31,6 +46,21 @@ def check_for_time_conflicts(candidate_sessions, existing_sessions, historical_t
         candidate_start = candidate.start_time
         candidate_end = (candidate_start + timedelta(minutes=candidate.length or 0)
                          if candidate_start else None)
+
+        # Checked before anything else: there is no point working out who to email
+        # about a clash for a session that is already too close to file for.
+        if candidate_start and hours > 0:
+            start_utc = candidate_start
+            if start_utc.tzinfo is None:
+                start_utc = start_utc.replace(tzinfo=timezone.utc)
+            if start_utc <= last_minute_cutoff:
+                candidate.is_conflict = True
+                candidate.conflict_type = "last_minute"
+                candidate.conflict_details = (
+                    f"Starts within {hours} hours, too late for the GN to action a "
+                    f"request. Book it by hand if it still needs a ticket."
+                )
+                continue
 
         if candidate_start:
             for existing in existing_sessions:

--- a/emailer.py
+++ b/emailer.py
@@ -75,11 +75,11 @@ def send_conflict_email(to_email, conflict_sessions, subject_prefix="GN Ticket A
     ]
 
     for session in conflict_sessions:
-        lines.append(f"- {session.get('title', 'Unknown')} | {session.get('school', 'Unknown')} | {session.get('start_time', 'Unknown')}")
+        lines.append(f"- {session.get('title', 'Unknown')} | {session.get('school', 'Unknown')} | {friendly_datetime(session.get('start_time'))}")
         if session.get('conflict_details'):
             lines.append(f"  Reason: {session.get('conflict_details')}")
         if session.get('conflict_start_iso') and session.get('conflict_end_iso'):
-            lines.append(f"  Conflict window: {session.get('conflict_start_iso')} – {session.get('conflict_end_iso')}")
+            lines.append(f"  Conflict window: {friendly_datetime(session.get('conflict_start_iso'))} – {friendly_datetime(session.get('conflict_end_iso'))}")
         lines.append("")
 
     lines.append("Resolve these in Airtable, or book them by hand from the dashboard.")
@@ -149,7 +149,7 @@ def send_booking_summary_email(to_email, successful_sessions, failed_sessions,
 
 
 def send_daily_summary_email(to_email, booked_sessions, conflict_sessions, summary_date,
-                             subject_prefix="GN Ticket Auto-Booking"):
+                             excluded_sessions=None, subject_prefix="GN Ticket Auto-Booking"):
     """The end-of-day picture: what was filed today, then what still needs a person.
 
     Sent once a day rather than after every run, so a short booking interval does
@@ -157,6 +157,7 @@ def send_daily_summary_email(to_email, booked_sessions, conflict_sessions, summa
     """
     booked_sessions = booked_sessions or []
     conflict_sessions = conflict_sessions or []
+    excluded_sessions = excluded_sessions or []
 
     lines = [f"GN ticket summary for {summary_date}.", ""]
 
@@ -164,7 +165,7 @@ def send_daily_summary_email(to_email, booked_sessions, conflict_sessions, summa
         lines.append(f"BOOKED TODAY ({len(booked_sessions)})")
         lines.append("")
         for session in booked_sessions:
-            lines.append(f"- {session.get('title', 'Unknown Session')} | {session.get('school', 'Unknown School')} | {session.get('start_time', 'Unknown')}")
+            lines.append(f"- {session.get('title', 'Unknown Session')} | {session.get('school', 'Unknown School')} | {friendly_datetime(session.get('start_time'))}")
             lines.append(f"  Ticket: {session.get('ticket_id', 'Unknown')}")
         lines.append("")
     else:
@@ -177,7 +178,7 @@ def send_daily_summary_email(to_email, booked_sessions, conflict_sessions, summa
         lines.append(f"CONFLICTS NEEDING YOU ({len(conflict_sessions)})")
         lines.append("")
         for session in conflict_sessions:
-            lines.append(f"- {session.get('title', 'Unknown')} | {session.get('school', 'Unknown')} | {session.get('start_time', 'Unknown')}")
+            lines.append(f"- {session.get('title', 'Unknown')} | {session.get('school', 'Unknown')} | {friendly_datetime(session.get('start_time'))}")
             if session.get('conflict_details'):
                 lines.append(f"  Reason: {session.get('conflict_details')}")
         lines.append("")
@@ -186,6 +187,16 @@ def send_daily_summary_email(to_email, booked_sessions, conflict_sessions, summa
         lines.append("CONFLICTS NEEDING YOU")
         lines.append("")
         lines.append("- None. Everything upcoming is either booked or has no conflict.")
+
+    if excluded_sessions:
+        lines.append("")
+        lines.append(f"REMOVED, NOT BEING BOOKED ({len(excluded_sessions)})")
+        lines.append("")
+        for session in excluded_sessions:
+            lines.append(f"- {session.get('title', 'Unknown')} | {session.get('school', 'Unknown')} | {friendly_datetime(session.get('start_time'))}")
+        lines.append("")
+        lines.append("You took these off the list on the dashboard, so no run will book "
+                     "them. Put one back with 'Process anyway' if that has changed.")
 
     subject = f"{subject_prefix}: Daily summary for {summary_date}"
     _send(to_email, subject, "\n".join(lines))

--- a/emailer.py
+++ b/emailer.py
@@ -1,6 +1,45 @@
 import os
 import smtplib
+from datetime import datetime, timezone
 from email.message import EmailMessage
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Timestamps are stored as naive UTC but read by people in one place, so anything
+# shown on a page or in an email is rendered in this zone.
+DISPLAY_TZ = os.getenv("AUTO_SCAN_TZ", "America/Toronto")
+
+
+def friendly_datetime(value, fallback="unknown"):
+    """Render a timestamp as 'Wed, Aug 19 at 8:36 pm' in the display timezone.
+
+    Accepts an ISO string or a datetime. A naive value is taken as UTC, which is how
+    every timestamp in this app is stored.
+    """
+    if not value:
+        return fallback
+
+    moment = value
+    if isinstance(moment, str):
+        try:
+            moment = datetime.fromisoformat(moment.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+    if not isinstance(moment, datetime):
+        return fallback
+
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+
+    try:
+        local = moment.astimezone(ZoneInfo(DISPLAY_TZ))
+    except ZoneInfoNotFoundError:
+        local = moment.astimezone(timezone.utc)
+
+    # %-d / %-I are not portable to Windows, so strip the padding by hand.
+    day = str(local.day)
+    hour = str((local.hour % 12) or 12)
+    meridiem = "am" if local.hour < 12 else "pm"
+    return f"{local:%a}, {local:%b} {day} at {hour}:{local:%M} {meridiem}"
 
 
 def _send(to_email, subject, body):
@@ -49,22 +88,35 @@ def send_conflict_email(to_email, conflict_sessions, subject_prefix="GN Ticket A
 
 
 def send_booking_summary_email(to_email, successful_sessions, failed_sessions,
+                               conflict_sessions=None, manual=False,
                                subject_prefix="GN Ticket Auto-Booking"):
-    """Report what an automated booking run submitted, and what it could not."""
+    """Report what a booking run submitted, what failed, and what it would not touch.
+
+    A manual run always sends, even when there was nothing to do: the dashboard
+    promised an email when the person pressed the button, so silence would read as
+    the run having got stuck.
+    """
     successful_sessions = successful_sessions or []
     failed_sessions = failed_sessions or []
+    conflict_sessions = conflict_sessions or []
 
-    if not successful_sessions and not failed_sessions:
+    if not (successful_sessions or failed_sessions or conflict_sessions) and not manual:
         return
 
     lines = []
+    if manual:
+        lines.append("The booking run you started from the dashboard has finished.")
+        lines.append("")
 
     if successful_sessions:
         lines.append(f"Booked {len(successful_sessions)} session(s) with GN:")
         lines.append("")
         for session in successful_sessions:
-            lines.append(f"- {session.get('title', 'Unknown Session')} | {session.get('school', 'Unknown School')} | {session.get('start_time', 'Unknown')}")
+            lines.append(f"- {session.get('title', 'Unknown Session')} | {session.get('school', 'Unknown School')} | {friendly_datetime(session.get('start_time'))}")
             lines.append(f"  Ticket: {session.get('ticket_id', 'Unknown')}")
+        lines.append("")
+    elif manual:
+        lines.append("No sessions were booked.")
         lines.append("")
 
     if failed_sessions:
@@ -75,10 +127,23 @@ def send_booking_summary_email(to_email, successful_sessions, failed_sessions,
             lines.append(f"  Error: {session.get('error', 'Unknown error')}")
         lines.append("")
         lines.append("These will be retried on the next scheduled run.")
+        lines.append("")
+
+    if conflict_sessions:
+        lines.append(f"{len(conflict_sessions)} session(s) were skipped because they conflict:")
+        lines.append("")
+        for session in conflict_sessions:
+            lines.append(f"- {session.get('title', 'Unknown')} | {session.get('school', 'Unknown')} | {friendly_datetime(session.get('start_time'))}")
+            if session.get('conflict_details'):
+                lines.append(f"  Reason: {session.get('conflict_details')}")
+        lines.append("")
+        lines.append("Resolve these in Airtable, or book them by hand from the dashboard.")
 
     subject = f"{subject_prefix}: Booked {len(successful_sessions)} session(s)"
     if failed_sessions:
         subject += f", {len(failed_sessions)} failed"
+    if conflict_sessions:
+        subject += f", {len(conflict_sessions)} conflicted"
 
     _send(to_email, subject, "\n".join(lines))
 

--- a/main.py
+++ b/main.py
@@ -452,6 +452,9 @@ def gn_ticket_page():
         submitted_ticket_log = ticket_log.get_entries(user['email'], window_past_days=window_past_days)
         submitted_ticket_log = sorted(submitted_ticket_log, key=lambda entry: entry.get('submitted_at', ''), reverse=True)
 
+        # Sessions taken off the list previously. They stay off it until put back.
+        excluded_ids = tasks.excluded_session_ids(user['email'])
+
         session['book_session_ids'] = [s.s_id for s in candidate_sessions]
 
         latest_conflicts = []
@@ -491,6 +494,7 @@ def gn_ticket_page():
             submitted_ticket_log=submitted_ticket_log,
             latest_conflicts=latest_conflicts,
             emailed_conflict_ids=emailed_conflict_ids,
+            excluded_ids=excluded_ids,
             user=user,
             buffer_before=buffer_before,
             buffer_after=buffer_after,
@@ -531,6 +535,8 @@ def do_gn_ticket():
     selected_ids = set(get_enabled_sessions(request))
     candidate_ids = set(session.get('book_session_ids', []))
     effective_ids = selected_ids.intersection(candidate_ids) if candidate_ids else selected_ids
+    # A removed session is never booked, whatever the form happens to say.
+    effective_ids -= tasks.excluded_session_ids(user['email'])
 
     airtable_client = create_airtable_client(profile['airtable_api_key'])
     candidate_sessions = airtable_client.get_booked_sessions(
@@ -662,6 +668,43 @@ def record_conflict_email():
         return jsonify({'ok': True})
     except Exception as e:
         logging.error(f"conflict_emailed error: {e}", exc_info=True)
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+
+@app.route("/gn_ticket/set_excluded", methods=["POST"])
+@require_auth
+def set_session_excluded_route():
+    """Remove a session from booking, or put it back. Sticks across future runs."""
+    user = session['user']
+    data = request.get_json(silent=True) or {}
+    session_id = (data.get('session_id') or '').strip()
+    if not session_id:
+        return jsonify({'ok': False, 'error': 'missing session_id'}), 400
+
+    excluded = bool(data.get('excluded'))
+    start_time = None
+    raw_start = (data.get('start_time') or '').strip()
+    if raw_start:
+        try:
+            parsed = datetime.fromisoformat(raw_start.replace('Z', '+00:00'))
+            # Stored naive UTC, matching every other timestamp in the database.
+            start_time = (parsed.astimezone(timezone.utc).replace(tzinfo=None)
+                          if parsed.tzinfo else parsed)
+        except ValueError:
+            logging.info("Ignoring unparseable start_time %r for %s", raw_start, session_id)
+
+    try:
+        ok = tasks.set_session_excluded(
+            user['email'], session_id, excluded,
+            title=(data.get('title') or '').strip() or None,
+            school=(data.get('school') or '').strip() or None,
+            start_time=start_time,
+        )
+        if not ok:
+            return jsonify({'ok': False, 'error': 'user not found'}), 404
+        return jsonify({'ok': True, 'excluded': excluded})
+    except Exception as e:
+        logging.error(f"set_excluded error: {e}", exc_info=True)
         return jsonify({'ok': False, 'error': str(e)}), 500
 
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from flask import request
 import json
 import time
 import threading 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 from dotenv import load_dotenv
 import secrets
@@ -106,11 +106,13 @@ from ticket_submission_log import TicketSubmissionLog
 from google_auth_oauthlib.flow import Flow
 from collections import deque
 from conflict import check_for_time_conflicts
+from emailer import friendly_datetime, send_booking_summary_email
 from db import DATABASE_URL, SessionLocal
 from models import ScanResult, User, ConflictEmailLog
 import tasks
 from tasks import auto_scan_time_label, booking_in_progress, booking_slot, busy_notice, dispatch_scan
-from user_profiles import SCAN_FREQUENCY_CHOICES, normalize_scan_frequency
+from user_profiles import (LOOKAHEAD_FOREVER_DAYS, LOOKAHEAD_STOPS, SCAN_FREQUENCY_CHOICES,
+                           normalize_lookahead, normalize_scan_frequency)
 import render_api
 
 # Global progress storage. Each session keeps a deque of the most recent entries
@@ -167,6 +169,21 @@ app.config['SESSION_SQLALCHEMY_TABLE'] = 'flask_sessions'
 # SQL has no TTL, so expired rows are pruned on roughly every Nth request.
 app.config['SESSION_CLEANUP_N_REQUESTS'] = 200
 Session(app)
+
+app.jinja_env.filters['friendly_datetime'] = friendly_datetime
+
+
+def notify_booking_finished(user_email, successful, failed, conflicts=None):
+    """Email the result of a booking someone started by hand.
+
+    Best-effort: a booking that worked must not be reported as a failure because the
+    mail relay was down, and the outcome is on the progress page regardless.
+    """
+    try:
+        send_booking_summary_email(user_email, successful, failed,
+                                   conflict_sessions=conflicts, manual=True)
+    except Exception as exc:
+        logging.error("Could not send booking summary to %s: %s", user_email, exc)
 
 CONFIG, CONFIG_VALID = load_config_from_env()
 
@@ -397,6 +414,21 @@ def gn_ticket_page():
         auto_booking_enabled = prefs.get('auto_booking_enabled', False)
         scan_frequency_hours = prefs.get('scan_frequency_hours', 24)
 
+        # The look-ahead slider narrows the visible sessions in the browser without a
+        # round trip. Widening it needs sessions this page never loaded, so the slider
+        # reloads with ?future_days=N and the fresh window is pulled from Airtable
+        # below. Saving it keeps the scheduled run looking at the same horizon.
+        requested_future_days = request.args.get('future_days')
+        if requested_future_days is not None:
+            window_future_days = normalize_lookahead(requested_future_days)
+            if window_future_days != prefs.get('window_future_days'):
+                user_manager.update_preferences(user['email'],
+                                                {'window_future_days': window_future_days})
+
+        lookahead_index = next(
+            (i for i, (days, _) in enumerate(LOOKAHEAD_STOPS) if days == window_future_days), 0)
+        lookahead_label = LOOKAHEAD_STOPS[lookahead_index][1]
+
         airtable_client = create_airtable_client(profile['airtable_api_key'])
         candidate_sessions = airtable_client.get_booked_sessions(
             user_email=user['email'],
@@ -464,6 +496,10 @@ def gn_ticket_page():
             buffer_after=buffer_after,
             window_past_days=window_past_days,
             window_future_days=window_future_days,
+            lookahead_stops=LOOKAHEAD_STOPS,
+            lookahead_forever_days=LOOKAHEAD_FOREVER_DAYS,
+            lookahead_index=lookahead_index,
+            lookahead_label=lookahead_label,
             auto_booking_enabled=auto_booking_enabled,
             scan_frequency_hours=scan_frequency_hours,
             scan_frequency_choices=SCAN_FREQUENCY_CHOICES,
@@ -557,9 +593,18 @@ def do_gn_ticket():
                     buffer_after=buffer_after
                 )
             ticket_log.add_successful_submissions(user['email'], booking_results.get('successful_sessions', []))
+            notify_booking_finished(
+                user['email'],
+                booking_results.get('successful_sessions', []),
+                booking_results.get('failed_sessions', []),
+            )
         except Exception as e:
             set_progress(progress_session_id, f"Critical error during booking: {str(e)}", status="error")
             logging.error(f"Booking thread failed: {e}", exc_info=True)
+            notify_booking_finished(
+                user['email'], [],
+                [{'title': f"{len(send_to_gn)} session(s)", 'error': str(e)}],
+            )
 
     threading.Thread(target=run_booking, daemon=True).start()
 
@@ -704,10 +749,13 @@ def update_preferences():
         "buffer_before": int(request.form.get("buffer_before", 10) or 0),
         "buffer_after": int(request.form.get("buffer_after", 10) or 0),
         "window_past_days": int(request.form.get("window_past_days", 14) or 0),
-        "window_future_days": int(request.form.get("window_future_days", 90) or 0),
         "auto_booking_enabled": request.form.get("auto_booking_enabled") == "yes",
         "scan_frequency_hours": normalize_scan_frequency(request.form.get("scan_frequency_hours")),
     }
+    # The look-ahead lives on the slider, not in this form. Only write it when it was
+    # actually submitted, or saving settings would snap the slider back to the default.
+    if "window_future_days" in request.form:
+        prefs["window_future_days"] = normalize_lookahead(request.form.get("window_future_days"))
     user_manager.update_preferences(user['email'], prefs)
     return redirect(url_for('gn_ticket_page'))
 
@@ -725,7 +773,9 @@ def run_auto_scan_now():
     if MANUAL_BOOKING_ENABLED:
         # Desktop build: do it here, where there is memory for a browser.
         threading.Thread(target=dispatch_scan, args=(user['email'],), daemon=True).start()
-        session['scan_notice'] = "Booking started."
+        session['scan_notice'] = ("The booker is running. You will get an email at "
+                                  f"{user['email']} when it finishes, with anything booked, "
+                                  "skipped for a conflict, or failed.")
         return redirect(url_for('gn_ticket_page'))
 
     # Hosted: the scan job has the memory for Chrome, this process does not.
@@ -738,6 +788,9 @@ def run_auto_scan_now():
         return redirect(url_for('gn_ticket_page'))
 
     ok, message = render_api.trigger_scan_job()
+    if ok:
+        message = (f"{message} You will get an email at {user['email']} when it finishes, "
+                   "with anything booked, skipped for a conflict, or failed.")
     session['scan_notice'] = message
     if not ok:
         logging.info("On-demand scan for %s fell back to the schedule.", user['email'])

--- a/models.py
+++ b/models.py
@@ -80,6 +80,28 @@ class ConflictEmailLog(Base):
     emailed_at = Column(DateTime, default=utcnow)
 
 
+class SessionExclusion(Base):
+    """A session the person removed on the dashboard, held back from every future run.
+
+    "Remove" used to last only until the page was reloaded, so a session someone had
+    deliberately taken out came straight back and was booked by the next scheduled
+    run. A row here is the decision, and it stands until they put the session back.
+
+    The title/school/start are a snapshot taken when it was removed, so the daily
+    summary can name the session without going back to Airtable for something that
+    is deliberately not in the candidate list any more.
+    """
+    __tablename__ = "session_exclusions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    session_id = Column(String(255), nullable=False, index=True)
+    title = Column(String(512))
+    school = Column(String(512))
+    start_time = Column(DateTime)
+    excluded_at = Column(DateTime, default=utcnow, nullable=False)
+
+
 class TaskLock(Base):
     """Cross-process mutex.
 

--- a/render.yaml
+++ b/render.yaml
@@ -96,5 +96,19 @@ services:
 
 databases:
   - name: gn-ticket-db
+    # Not `free`: a free Postgres expires 30 days after creation and is then deleted,
+    # and it cannot be upgraded to a paid instance. This database holds every user's
+    # encrypted Airtable key, ServiceNow password and 2FA secret — losing it monthly
+    # would mean everyone redoing the setup wizard. basic-256mb is the same 256 MB /
+    # 0.1 CPU as free, and only the storage was ever oversized.
     plan: basic-256mb
+    # 1 GB, the smallest there is. This stores text: users, tickets, scan results and
+    # sessions. Storage bills at $0.30/GB/month, so this is $0.30 rather than the
+    # $4.50 that 15 GB costs.
+    #
+    # Render can only ever GROW a database's disk — "you can increase an existing
+    # database's storage at any time, but you can't reduce it". So this line does not
+    # shrink the live database; it only applies to one created fresh. Shrinking means
+    # creating a new database and repointing DATABASE_URL.
+    diskSizeGB: 1
     databaseName: gn_ticket

--- a/tasks.py
+++ b/tasks.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from airtable_integration import create_airtable_client
 from conflict import check_for_time_conflicts
 from db import SessionLocal
-from emailer import send_conflict_email, send_daily_summary_email
+from emailer import send_booking_summary_email, send_conflict_email, send_daily_summary_email
 from models import (ConflictEmailLog, DailySummaryLog, ScanRequest, ScanResult,
                     TaskLock, TicketSubmission, User)
 from ticket_submission_log import TicketSubmissionLog
@@ -388,11 +388,11 @@ def dispatch_scan(user_email):
     return scan_user.delay(user_email)
 
 
-def dispatch_booking(user_email, session_ids):
+def dispatch_booking(user_email, session_ids, manual=False):
     """Queue a booking run, or run it here when there is no broker."""
     if INLINE_TASKS:
-        return book_sessions(user_email, session_ids)
-    return book_sessions.delay(user_email, session_ids)
+        return book_sessions(user_email, session_ids, manual)
+    return book_sessions.delay(user_email, session_ids, manual)
 
 
 def last_scan_at(user_email):
@@ -527,6 +527,9 @@ def _scan_user(user_email):
                 user_email, len(candidate_sessions), len(clean), len(conflicts))
 
     _record_scan(user_email, candidate_sessions, conflict_payload, clean)
+    # A pending request means a person pressed "Book now" and is waiting on an email.
+    # Read it before clearing, since clearing is what marks the request as served.
+    manual = has_pending_request(user_email)
     # Satisfied: this scan covers whatever prompted the request.
     clear_scan_request(user_email)
 
@@ -538,19 +541,26 @@ def _scan_user(user_email):
             logger.error("Could not send conflict email to %s: %s", user_email, exc)
 
     if clean:
-        dispatch_booking(user_email, [s.s_id for s in clean])
+        dispatch_booking(user_email, [s.s_id for s in clean], manual=manual)
+    elif manual:
+        # Nothing to book, but the button promised an email either way.
+        try:
+            send_booking_summary_email(user_email, [], [],
+                                       conflict_sessions=conflict_payload, manual=True)
+        except Exception as exc:
+            logger.error("Could not send booking summary to %s: %s", user_email, exc)
 
 
 @celery_app.task(name="tasks.book_sessions")
-def book_sessions(user_email, session_ids):
+def book_sessions(user_email, session_ids, manual=False):
     with _user_lock(f"book:{user_email}", BOOK_LOCK_TTL) as acquired:
         if not acquired:
             logger.info("Booking for %s already running; skipping this batch.", user_email)
             return
-        _book_sessions(user_email, session_ids)
+        _book_sessions(user_email, session_ids, manual=manual)
 
 
-def _book_sessions(user_email, session_ids):
+def _book_sessions(user_email, session_ids, manual=False):
     if not user_manager.is_profile_complete(user_email):
         logger.info("Skipping booking for %s: profile incomplete.", user_email)
         return
@@ -578,6 +588,18 @@ def _book_sessions(user_email, session_ids):
 
     requested = set(session_ids)
     send_to_gn = [s for s in candidate_sessions if s.s_id in requested and not s.is_conflict]
+    conflicted = [_session_to_dict(s) for s in candidate_sessions if s.is_conflict]
+
+    def report(successful=None, failed=None):
+        """Tell the person who pressed the button how it went. Only they are waiting
+        on it — a scheduled run reports through the daily summary instead."""
+        if not manual:
+            return
+        try:
+            send_booking_summary_email(user_email, successful or [], failed or [],
+                                       conflict_sessions=conflicted, manual=True)
+        except Exception as exc:
+            logger.error("Could not send booking summary to %s: %s", user_email, exc)
 
     skipped = len(requested) - len(send_to_gn)
     if skipped > 0:
@@ -585,6 +607,7 @@ def _book_sessions(user_email, session_ids):
                     skipped, len(requested), user_email)
 
     if not send_to_gn:
+        report()
         return
 
     if MAX_BOOKINGS_PER_RUN and len(send_to_gn) > MAX_BOOKINGS_PER_RUN:
@@ -602,6 +625,7 @@ def _book_sessions(user_email, session_ids):
             ", ".join(f"{s.s_id} ({s.title} @ {s.school})" for s in send_to_gn),
         )
         _record_booking_outcome(user_email, [], [])
+        report()
         return {"dry_run": True, "would_book": [s.s_id for s in send_to_gn]}
 
     gn_ticket.set_progress_callback(lambda *args, **kwargs: None)
@@ -618,22 +642,32 @@ def _book_sessions(user_email, session_ids):
                 "for the next run — nothing is lost, they stay unbooked in Airtable.",
                 BUSY_MAX_WAIT_SECONDS // 60, user_email, len(send_to_gn),
             )
+            report(failed=[{"title": f"{len(send_to_gn)} session(s)",
+                            "error": "The browser was still busy after a long wait. Nothing "
+                                     "was booked; the next run picks these up."}])
             return
 
-        booking_results = gn_ticket.gn_ticket_handler(
-            send_to_gn,
-            user_email,
-            profile.get("servicenow_password"),
-            "connectednorth@takingitglobal.org",
-            None,
-            profile.get("airtable_api_key"),
-            profile.get("totp_secret"),
-            headless_mode=True,
-            allow_manual_site_selection=False,
-            chatgpt_api_key=os.getenv("CHATGPT_API_KEY"),
-            buffer_before=buffer_before,
-            buffer_after=buffer_after,
-        )
+        try:
+            booking_results = gn_ticket.gn_ticket_handler(
+                send_to_gn,
+                user_email,
+                profile.get("servicenow_password"),
+                "connectednorth@takingitglobal.org",
+                None,
+                profile.get("airtable_api_key"),
+                profile.get("totp_secret"),
+                headless_mode=True,
+                allow_manual_site_selection=False,
+                chatgpt_api_key=os.getenv("CHATGPT_API_KEY"),
+                buffer_before=buffer_before,
+                buffer_after=buffer_after,
+            )
+        except Exception as exc:
+            # Someone is waiting on an email for this run; a silent crash looks
+            # identical to a run that is still going.
+            logger.error("Booking run failed for %s: %s", user_email, exc, exc_info=True)
+            report(failed=[{"title": f"{len(send_to_gn)} session(s)", "error": str(exc)}])
+            raise
 
     successful = booking_results.get("successful_sessions", [])
     failed = booking_results.get("failed_sessions", [])
@@ -642,6 +676,7 @@ def _book_sessions(user_email, session_ids):
     _record_booking_outcome(user_email, successful, failed)
 
     logger.info("Booking for %s: %d succeeded, %d failed.", user_email, len(successful), len(failed))
+    report(successful=successful, failed=failed)
 
 
 def _local_now():

--- a/tasks.py
+++ b/tasks.py
@@ -20,7 +20,7 @@ from conflict import check_for_time_conflicts
 from db import SessionLocal
 from emailer import send_booking_summary_email, send_conflict_email, send_daily_summary_email
 from models import (ConflictEmailLog, DailySummaryLog, ScanRequest, ScanResult,
-                    TaskLock, TicketSubmission, User)
+                    SessionExclusion, TaskLock, TicketSubmission, User)
 from ticket_submission_log import TicketSubmissionLog
 from user_profiles import DEFAULT_SCAN_FREQUENCY_HOURS, user_manager
 import gn_ticket
@@ -442,6 +442,82 @@ def clear_scan_request(user_email):
         db.commit()
 
 
+def excluded_session_ids(user_email):
+    """Sessions this person removed on the dashboard. Never booked automatically."""
+    with SessionLocal() as db:
+        user = db.execute(select(User).where(User.email == user_email.strip().lower())).scalar_one_or_none()
+        if not user:
+            return set()
+        return {
+            session_id for (session_id,) in db.execute(
+                select(SessionExclusion.session_id).where(SessionExclusion.user_id == user.id)
+            ).all()
+        }
+
+
+def set_session_excluded(user_email, session_id, excluded, title=None, school=None,
+                         start_time=None):
+    """Record, or undo, a decision not to book a session. Idempotent either way."""
+    with SessionLocal() as db:
+        user = db.execute(select(User).where(User.email == user_email.strip().lower())).scalar_one_or_none()
+        if not user:
+            return False
+
+        if not excluded:
+            db.execute(sa_delete(SessionExclusion).where(
+                SessionExclusion.user_id == user.id,
+                SessionExclusion.session_id == session_id,
+            ))
+            db.commit()
+            return True
+
+        existing = db.execute(select(SessionExclusion).where(
+            SessionExclusion.user_id == user.id,
+            SessionExclusion.session_id == session_id,
+        )).scalars().first()
+        if existing:
+            # Already removed; refresh the snapshot in case the session moved.
+            existing.title = title or existing.title
+            existing.school = school or existing.school
+            existing.start_time = start_time or existing.start_time
+        else:
+            db.add(SessionExclusion(user_id=user.id, session_id=session_id, title=title,
+                                    school=school, start_time=start_time))
+        db.commit()
+        return True
+
+
+def outstanding_exclusions(user_email, now=None):
+    """Removed sessions that have not happened yet — the ones still being held back.
+
+    A session in the past can never be booked again, so listing it would just grow
+    the daily email forever.
+    """
+    now = now or datetime.utcnow()
+    with SessionLocal() as db:
+        user = db.execute(select(User).where(User.email == user_email.strip().lower())).scalar_one_or_none()
+        if not user:
+            return []
+        rows = db.execute(
+            select(SessionExclusion)
+            .where(SessionExclusion.user_id == user.id)
+            .order_by(SessionExclusion.start_time.asc())
+        ).scalars().all()
+
+    upcoming = []
+    for row in rows:
+        if row.start_time and row.start_time.replace(tzinfo=None) < now:
+            continue
+        upcoming.append({
+            "session_id": row.session_id,
+            "title": row.title,
+            "school": row.school,
+            "start_time": row.start_time.replace(tzinfo=timezone.utc).isoformat()
+            if row.start_time else None,
+        })
+    return upcoming
+
+
 def user_is_due(user_email, now=None):
     """Whether this user's chosen interval has elapsed since their last scan.
 
@@ -519,8 +595,13 @@ def _scan_user(user_email):
         airtable_client, candidate_sessions, user_email, window_past_days, window_future_days
     )
 
-    conflicts = [s for s in candidate_sessions if s.is_conflict]
-    clean = [s for s in candidate_sessions if not s.is_conflict]
+    # Sessions the person took off the list stay off it. Held back before anything
+    # else looks at them, so a removed session is never booked and never emailed
+    # about as a conflict either — the decision has already been made.
+    excluded = excluded_session_ids(user_email)
+    conflicts = [s for s in candidate_sessions if s.is_conflict and s.s_id not in excluded]
+    clean = [s for s in candidate_sessions
+             if not s.is_conflict and s.s_id not in excluded]
     conflict_payload = [_session_to_dict(s) for s in conflicts]
 
     logger.info("Scan for %s: %d candidate(s), %d clean, %d conflicted.",
@@ -586,9 +667,13 @@ def _book_sessions(user_email, session_ids, manual=False):
         airtable_client, candidate_sessions, user_email, window_past_days, window_future_days
     )
 
-    requested = set(session_ids)
+    # Re-read rather than trusting the ids we were handed: someone may have removed a
+    # session on the dashboard between the scan and this run.
+    excluded = excluded_session_ids(user_email)
+    requested = {sid for sid in session_ids if sid not in excluded}
     send_to_gn = [s for s in candidate_sessions if s.s_id in requested and not s.is_conflict]
-    conflicted = [_session_to_dict(s) for s in candidate_sessions if s.is_conflict]
+    conflicted = [_session_to_dict(s) for s in candidate_sessions
+                  if s.is_conflict and s.s_id not in excluded]
 
     def report(successful=None, failed=None):
         """Tell the person who pressed the button how it went. Only they are waiting
@@ -600,6 +685,11 @@ def _book_sessions(user_email, session_ids, manual=False):
                                        conflict_sessions=conflicted, manual=True)
         except Exception as exc:
             logger.error("Could not send booking summary to %s: %s", user_email, exc)
+
+    removed = len(session_ids) - len(requested)
+    if removed > 0:
+        logger.info("Holding back %d of %d session(s) for %s: removed on the dashboard.",
+                    removed, len(session_ids), user_email)
 
     skipped = len(requested) - len(send_to_gn)
     if skipped > 0:
@@ -780,6 +870,7 @@ def send_daily_summaries(force=False):
                 sessions_booked_on(email, now_local.date()),
                 outstanding_conflicts(email),
                 summary_date,
+                excluded_sessions=outstanding_exclusions(email),
             )
             _record_summary_sent(email, summary_date)
             sent += 1

--- a/templates/gn.html
+++ b/templates/gn.html
@@ -141,6 +141,53 @@ body {
 .submission-log th {
   background: #eef3f8;
 }
+.lookahead {
+  margin: 22px 0 18px;
+  padding: 14px 18px 10px;
+  background: #f7f9fc;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+}
+.lookahead-label {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 0.95rem;
+  color: #333;
+}
+.lookahead-range {
+  width: 100%;
+  margin: 0;
+  height: 28px;
+  accent-color: #2c7be5;
+  cursor: pointer;
+}
+/* The labels sit under the thumb's travel, so the first and last are pulled inward
+   by half a thumb width to line up with the ends of the track rather than the box. */
+.lookahead-scale {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 8px;
+  font-size: 0.78rem;
+  color: #55606b;
+}
+.lookahead-stop {
+  flex: 1 1 0;
+  text-align: center;
+  white-space: nowrap;
+}
+.lookahead-stop:first-child { text-align: left; }
+.lookahead-stop:last-child { text-align: right; }
+.lookahead-stop.is-active {
+  color: #2c7be5;
+  font-weight: bold;
+}
+.lookahead-note {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: #55606b;
+  min-height: 1.2em;
+}
+.session[hidden] { display: none; }
 .gallery-scroll {
   max-height: 2600px;
   overflow-y: auto;
@@ -209,6 +256,98 @@ function toggleSession(btn) {
     $(btn).text('Remove').removeClass('btn-include').addClass('btn-exclude');
   }
 }
+
+// --- Look-ahead slider -------------------------------------------------------
+// Narrowing the window hides cards that are already on the page. Widening it past
+// the window this page was built with needs sessions the server never sent, so that
+// reloads with ?future_days=N and Airtable is queried again.
+// This script block lives in <head>, so wait for the cards to exist.
+document.addEventListener('DOMContentLoaded', function () {
+  var range = document.getElementById('lookahead-range');
+  if (!range) return;
+
+  var stops = [].map.call(document.querySelectorAll('.lookahead-stop'), function (el) {
+    return { days: parseInt(el.dataset.days, 10), label: el.textContent.trim(), el: el };
+  });
+  var loadedDays = parseInt(range.dataset.loadedDays, 10);
+  var valueLabel = document.getElementById('lookahead-value');
+  var note = document.getElementById('lookahead-note');
+
+  // End of the chosen day, local time, so "Today" keeps everything later today.
+  function cutoffFor(days) {
+    var end = new Date();
+    end.setHours(23, 59, 59, 999);
+    end.setDate(end.getDate() + days);
+    return end;
+  }
+
+  function applyFilter(days) {
+    var cutoff = cutoffFor(days);
+    var shown = 0, hidden = 0;
+
+    [].forEach.call(document.querySelectorAll('.session[data-start]'), function (card) {
+      var raw = card.dataset.start;
+      if (!raw) return;                       // no date: never filtered out
+      var start = new Date(raw);
+      if (isNaN(start.getTime())) return;
+
+      var bookMe = card.querySelector('input[name="book_me"]');
+      if (start > cutoff) {
+        if (!card.hasAttribute('hidden')) {
+          // Remember the choice so restoring does not book something the user removed.
+          if (bookMe) { card.dataset.bookMeBefore = bookMe.value; bookMe.value = 'n'; }
+          card.setAttribute('hidden', 'hidden');
+        }
+        hidden++;
+      } else {
+        if (card.hasAttribute('hidden')) {
+          if (bookMe && card.dataset.bookMeBefore !== undefined) {
+            bookMe.value = card.dataset.bookMeBefore;
+            delete card.dataset.bookMeBefore;
+          }
+          card.removeAttribute('hidden');
+        }
+        shown++;
+      }
+    });
+
+    note.textContent = hidden
+      ? shown + ' session(s) shown, ' + hidden + ' beyond this window hidden and not booked.'
+      : '';
+  }
+
+  function markActive(index) {
+    stops.forEach(function (stop, i) {
+      stop.el.classList.toggle('is-active', i === index);
+    });
+  }
+
+  function onChange() {
+    var stop = stops[parseInt(range.value, 10)];
+    if (!stop) return;
+    valueLabel.textContent = stop.label;
+    markActive(stops.indexOf(stop));
+
+    if (stop.days > loadedDays) {
+      // Beyond what this page loaded — go get the rest.
+      note.textContent = 'Loading sessions further ahead…';
+      var url = new URL(window.location.href);
+      url.searchParams.set('future_days', stop.days);
+      window.location.assign(url.toString());
+      return;
+    }
+    applyFilter(stop.days);
+  }
+
+  range.addEventListener('input', function () {
+    var stop = stops[parseInt(range.value, 10)];
+    if (stop) { valueLabel.textContent = stop.label; markActive(stops.indexOf(stop)); }
+  });
+  range.addEventListener('change', onChange);
+
+  markActive(parseInt(range.value, 10));
+  applyFilter(loadedDays);
+});
 
 function formatTimeInTz(isoString, timezone) {
   if (!isoString) return 'Unknown time';
@@ -373,13 +512,9 @@ document.addEventListener('DOMContentLoaded', function() {
         </span>
       </div>
       <div style="margin-top: 10px;">
-        <label style="margin-right: 10px;">
+        <label>
           Ticket history, past days:
           <input type="number" name="window_past_days" value="{{ window_past_days }}" style="width: 70px;">
-        </label>
-        <label>
-          Look ahead, days:
-          <input type="number" name="window_future_days" value="{{ window_future_days }}" style="width: 70px;">
         </label>
       </div>
       <div style="margin-top: 10px;">
@@ -405,7 +540,7 @@ document.addEventListener('DOMContentLoaded', function() {
       {% if latest_scan %}
       <div style="margin-top: 12px; font-size: 0.9em; color: #333;">
         <strong>Last automatic run:</strong>
-        {{ latest_scan.scanned_at or 'unknown' }} &middot;
+        {{ latest_scan.scanned_at | friendly_datetime }} &middot;
         {{ latest_scan.candidates or 0 }} candidate(s),
         {{ latest_scan.clean or 0 }} without conflicts,
         {{ latest_scan.conflicts or 0 }} conflicted
@@ -443,8 +578,29 @@ document.addEventListener('DOMContentLoaded', function() {
     <input type="submit" name="book_sessions" id="book_sessions" value="Book now"
            formaction="{{ '/gn_ticket/book_sessions' if manual_booking_enabled else '/auto/run' }}">
     <span style="margin-left: 10px; color: #555; font-size: 0.9em;">
-      Books every session below that has no conflict. Otherwise this happens on its own, {{ auto_scan_time }}.
+      These sessions will be booked on the next scheduled run, or you can book now.
     </span>
+
+    <!-- Look-ahead slider. Narrowing filters the cards already on the page; widening
+         past what was loaded reloads with a bigger window and re-pulls from Airtable. -->
+    <div class="lookahead" id="lookahead">
+      <label class="lookahead-label" for="lookahead-range">
+        Look ahead: <strong id="lookahead-value">{{ lookahead_label }}</strong>
+      </label>
+      <input type="range" id="lookahead-range" class="lookahead-range"
+             min="0" max="{{ lookahead_stops | length - 1 }}" step="1"
+             value="{{ lookahead_index }}" list="lookahead-ticks"
+             data-loaded-days="{{ window_future_days }}">
+      <datalist id="lookahead-ticks">
+        {% for days, label in lookahead_stops %}<option value="{{ loop.index0 }}"></option>{% endfor %}
+      </datalist>
+      <div class="lookahead-scale">
+        {% for days, label in lookahead_stops %}
+        <span class="lookahead-stop" data-index="{{ loop.index0 }}" data-days="{{ days }}">{{ label }}</span>
+        {% endfor %}
+      </div>
+      <div class="lookahead-note" id="lookahead-note"></div>
+    </div>
 
     <!-- Session Gallery Section -->
     <h3>Current candidate sessions</h3>
@@ -453,7 +609,8 @@ document.addEventListener('DOMContentLoaded', function() {
       {% if all_sessions %}
         {% for session in all_sessions %}
         {% set is_conflict = session.conflict_type %}
-        <div class="session{% if session.conflict_type == 'time' %} session-conflict{% elif session.conflict_type in ['gn_ticket', 'ghost_ticket'] %} session-gn-warning{% endif %}{% if is_conflict %} session-excluded{% endif %}">
+        <div class="session{% if session.conflict_type == 'time' %} session-conflict{% elif session.conflict_type in ['gn_ticket', 'ghost_ticket'] %} session-gn-warning{% endif %}{% if is_conflict %} session-excluded{% endif %}"
+             data-start="{{ session.start_time.isoformat() if session.start_time else '' }}">
           <input name="book_me" type="hidden" id="{{session.s_id}}" value="{{ 'n' if is_conflict else 'y' }}">
           <input name="airtable_id" type="hidden" id="{{session.s_id}}_airtable" value="{{session.s_id}}">
 

--- a/templates/gn.html
+++ b/templates/gn.html
@@ -57,6 +57,28 @@ body {
   border-color: #f0ad4e;
   color: #8a6d3b;
 }
+.session.session-last-minute {
+  border-color: #8a6d3b;
+  box-shadow: 0 0 0 2px rgba(138, 109, 59, 0.15);
+}
+.conflict-banner.conflict-last-minute {
+  background: #fdf3e3;
+  border-color: #c9974a;
+  color: #7a5b1e;
+}
+/* A removal is the person's own decision rather than something to alarm them
+   about, so it reads as a plain note. */
+.conflict-banner.conflict-removed {
+  background: #eef1f5;
+  border-color: #9aa5b1;
+  color: #45505c;
+  font-weight: normal;
+}
+.exclusion-error {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #a94442;
+}
 .session-header {
   display: flex;
   justify-content: space-between;
@@ -246,7 +268,9 @@ body {
 function toggleSession(btn) {
   var sessionDiv = $(btn).closest('.session');
   var bookMeInput = sessionDiv.find('input[name="book_me"]');
-  if (bookMeInput.val() === 'y') {
+  var removing = bookMeInput.val() === 'y';
+
+  if (removing) {
     bookMeInput.val('n');
     sessionDiv.addClass('session-excluded');
     $(btn).text('Process anyway').removeClass('btn-exclude').addClass('btn-include');
@@ -255,6 +279,49 @@ function toggleSession(btn) {
     sessionDiv.removeClass('session-excluded');
     $(btn).text('Remove').removeClass('btn-include').addClass('btn-exclude');
   }
+
+  // The decision has to outlive this page: without it a removed session comes
+  // straight back on the next load and the next scheduled run books it.
+  persistExclusion(sessionDiv, removing, btn);
+}
+
+function persistExclusion(sessionDiv, excluded, btn) {
+  var sessionId = sessionDiv.data('session-id');
+  if (!sessionId) return;
+
+  $.ajax({
+    url: '/gn_ticket/set_excluded',
+    type: 'POST',
+    contentType: 'application/json',
+    data: JSON.stringify({
+      session_id: sessionId,
+      excluded: excluded,
+      title: sessionDiv.data('title') || '',
+      school: sessionDiv.data('school') || '',
+      start_time: sessionDiv.attr('data-start') || ''
+    })
+  }).done(function (res) {
+    if (!res || !res.ok) { showExclusionError(sessionDiv, btn, excluded); }
+    else { sessionDiv.find('.exclusion-error').remove(); }
+  }).fail(function () {
+    showExclusionError(sessionDiv, btn, excluded);
+  });
+}
+
+function showExclusionError(sessionDiv, btn, attempted) {
+  // Put the button back rather than letting the page imply something was saved.
+  var bookMeInput = sessionDiv.find('input[name="book_me"]');
+  if (attempted) {
+    bookMeInput.val('y');
+    sessionDiv.removeClass('session-excluded');
+    $(btn).text('Remove').removeClass('btn-include').addClass('btn-exclude');
+  } else {
+    bookMeInput.val('n');
+    sessionDiv.addClass('session-excluded');
+    $(btn).text('Process anyway').removeClass('btn-exclude').addClass('btn-include');
+  }
+  sessionDiv.find('.exclusion-error').remove();
+  sessionDiv.append('<div class="exclusion-error">Could not save that — not changed.</div>');
 }
 
 // --- Look-ahead slider -------------------------------------------------------
@@ -609,10 +676,21 @@ document.addEventListener('DOMContentLoaded', function() {
       {% if all_sessions %}
         {% for session in all_sessions %}
         {% set is_conflict = session.conflict_type %}
-        <div class="session{% if session.conflict_type == 'time' %} session-conflict{% elif session.conflict_type in ['gn_ticket', 'ghost_ticket'] %} session-gn-warning{% endif %}{% if is_conflict %} session-excluded{% endif %}"
-             data-start="{{ session.start_time.isoformat() if session.start_time else '' }}">
-          <input name="book_me" type="hidden" id="{{session.s_id}}" value="{{ 'n' if is_conflict else 'y' }}">
+        {% set is_removed = session.s_id in excluded_ids %}
+        {% set is_held = is_conflict or is_removed %}
+        <div class="session{% if session.conflict_type == 'time' %} session-conflict{% elif session.conflict_type == 'last_minute' %} session-last-minute{% elif session.conflict_type in ['gn_ticket', 'ghost_ticket'] %} session-gn-warning{% endif %}{% if is_held %} session-excluded{% endif %}"
+             data-start="{{ session.start_time.isoformat() if session.start_time else '' }}"
+             data-session-id="{{ session.s_id }}"
+             data-title="{{ session.title | e }}"
+             data-school="{{ session.school | e }}">
+          <input name="book_me" type="hidden" id="{{session.s_id}}" value="{{ 'n' if is_held else 'y' }}">
           <input name="airtable_id" type="hidden" id="{{session.s_id}}_airtable" value="{{session.s_id}}">
+
+          {% if is_removed %}
+          <div class="conflict-banner conflict-removed">
+            🚫 Removed — no scheduled run will book this until you put it back.
+          </div>
+          {% endif %}
 
           {% if session.conflict_type == 'time' %}
           <div class="conflict-banner conflict-time">
@@ -639,6 +717,8 @@ document.addEventListener('DOMContentLoaded', function() {
               {% endif %}
             {% endif %}
           </div>
+          {% elif session.conflict_type == 'last_minute' %}
+          <div class="conflict-banner conflict-last-minute">⏰ Last minute: {{ session.conflict_details }}</div>
           {% elif session.conflict_type == 'gn_ticket' %}
           <div class="conflict-banner conflict-gn-ticket">⚠️ GN ticket follow-up: {{ session.conflict_details }}</div>
           {% elif session.conflict_type == 'ghost_ticket' %}
@@ -647,7 +727,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
           <div class="session-header">
             <span class="session-title" title="{{ session.title }}">{{ session.title }}</span>
-            <button type="button" class="remove-btn {{ 'btn-include' if is_conflict else 'btn-exclude' }}" onclick="toggleSession(this)">{{ 'Process anyway' if is_conflict else 'Remove' }}</button>
+            <button type="button" class="remove-btn {{ 'btn-include' if is_held else 'btn-exclude' }}" onclick="toggleSession(this)">{{ 'Process anyway' if is_held else 'Remove' }}</button>
           </div>
 
           <div class="session-meta">

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -22,8 +22,9 @@ def sent(monkeypatch):
     """Capture the summary instead of mailing it."""
     captured = []
     monkeypatch.setattr(tasks, "send_daily_summary_email",
-                        lambda email, booked, conflicts, date: captured.append(
-                            {"email": email, "booked": booked, "conflicts": conflicts, "date": date}))
+                        lambda email, booked, conflicts, date, excluded_sessions=None: captured.append(
+                            {"email": email, "booked": booked, "conflicts": conflicts, "date": date,
+                             "excluded": list(excluded_sessions or [])}))
     return captured
 
 
@@ -161,7 +162,7 @@ def test_one_users_failure_does_not_stop_the_others(monkeypatch, registered_user
 
     reached = []
 
-    def flaky(email, booked, conflicts, date):
+    def flaky(email, booked, conflicts, date, excluded_sessions=None):
         if email == USER_EMAIL:
             raise RuntimeError("SMTP down")
         reached.append(email)

--- a/tests/test_last_minute.py
+++ b/tests/test_last_minute.py
@@ -1,0 +1,97 @@
+"""Sessions starting too soon are held back like a conflict.
+
+The GN cannot action a request filed hours before the session, so sending one is
+noise. These are reported instead, and can still be booked by hand.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from conflict import LAST_MINUTE_HOURS, check_for_time_conflicts
+
+
+NOW = datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)
+
+
+class DummySession:
+    def __init__(self, s_id, title, school, start_time, length=60,
+                 status="Booked", teacher="Teacher", gn_ticket_requested=False):
+        self.s_id = s_id
+        self.title = title
+        self.school = school
+        self.start_time = start_time
+        self.length = length
+        self.status = status
+        self.teacher = teacher
+        self.teacher_email = "teacher@example.com"
+        self.gn_ticket_requested = gn_ticket_requested
+        self.created_at = ""
+
+
+def check(sessions, existing=None, now=NOW):
+    return check_for_time_conflicts(sessions, existing or [], [], now=now)
+
+
+def test_default_window_is_twelve_hours():
+    assert LAST_MINUTE_HOURS == 12
+
+
+@pytest.mark.parametrize("hours_away", [0.5, 3, 11, 11.9])
+def test_sessions_inside_the_window_are_flagged(hours_away):
+    session = DummySession("rec1", "Soon", "School A", NOW + timedelta(hours=hours_away))
+    result = check([session])[0]
+
+    assert result.is_conflict is True
+    assert result.conflict_type == "last_minute"
+    assert "12 hours" in result.conflict_details
+
+
+@pytest.mark.parametrize("hours_away", [12.1, 24, 200])
+def test_sessions_beyond_the_window_are_left_alone(hours_away):
+    session = DummySession("rec1", "Later", "School A", NOW + timedelta(hours=hours_away))
+    result = check([session])[0]
+
+    assert result.is_conflict is False
+    assert result.conflict_type is None
+
+
+def test_a_session_already_underway_counts_as_last_minute():
+    session = DummySession("rec1", "Started", "School A", NOW - timedelta(hours=2))
+    assert check([session])[0].conflict_type == "last_minute"
+
+
+def test_last_minute_wins_over_a_time_conflict():
+    """No point working out who to email about a clash that is hours away."""
+    soon = NOW + timedelta(hours=3)
+    candidate = DummySession("rec1", "Soon", "School A", soon)
+    existing = DummySession("rec2", "Already Ticketed", "School A", soon,
+                            gn_ticket_requested=True)
+
+    result = check([candidate], [existing])[0]
+
+    assert result.conflict_type == "last_minute"
+
+
+def test_it_does_not_drag_other_sessions_down_with_it():
+    soon = DummySession("rec1", "Soon", "School A", NOW + timedelta(hours=2))
+    later = DummySession("rec2", "Later", "School B", NOW + timedelta(days=5))
+
+    results = {s.s_id: s for s in check([soon, later])}
+
+    assert results["rec1"].is_conflict is True
+    assert results["rec2"].is_conflict is False
+
+
+def test_the_window_is_configurable():
+    session = DummySession("rec1", "Tomorrow", "School A", NOW + timedelta(hours=20))
+
+    assert check_for_time_conflicts([session], [], [], now=NOW,
+                                    last_minute_hours=24)[0].conflict_type == "last_minute"
+    assert check_for_time_conflicts([session], [], [], now=NOW,
+                                    last_minute_hours=12)[0].is_conflict is False
+
+
+def test_zero_hours_turns_the_rule_off():
+    session = DummySession("rec1", "Imminent", "School A", NOW + timedelta(minutes=5))
+    assert check_for_time_conflicts([session], [], [], now=NOW,
+                                    last_minute_hours=0)[0].is_conflict is False

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -1,0 +1,72 @@
+"""The look-ahead slider: fixed stops, and a preference that survives a settings save."""
+import pytest
+
+from user_profiles import (DEFAULT_LOOKAHEAD_DAYS, LOOKAHEAD_DAYS, LOOKAHEAD_FOREVER_DAYS,
+                           LOOKAHEAD_STOPS, normalize_lookahead, user_manager)
+
+
+USER_EMAIL = "lead@takingitglobal.org"
+
+
+def test_every_stop_normalizes_to_itself():
+    for days in LOOKAHEAD_DAYS:
+        assert normalize_lookahead(days) == days
+
+
+def test_today_is_zero_and_survives_normalization():
+    # 0 is falsy, which is exactly how "Today" used to get lost.
+    assert LOOKAHEAD_STOPS[0][0] == 0
+    assert normalize_lookahead(0) == 0
+    assert normalize_lookahead("0") == 0
+
+
+def test_labels_match_the_requested_scale():
+    assert [label for _, label in LOOKAHEAD_STOPS] == [
+        "Today", "7 days", "10 days", "14 days", "30 days", "60 days", "90 days", "Forever",
+    ]
+
+
+@pytest.mark.parametrize("value,expected", [
+    (45, 60),        # between stops: round up so nothing drops out of view
+    (1, 7),
+    (91, LOOKAHEAD_FOREVER_DAYS),
+    (99999, LOOKAHEAD_FOREVER_DAYS),
+])
+def test_values_between_stops_round_up(value, expected):
+    assert normalize_lookahead(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, "", "abc", object()])
+def test_junk_falls_back_to_the_default(value):
+    assert normalize_lookahead(value) == DEFAULT_LOOKAHEAD_DAYS
+
+
+def _register():
+    user_manager.upsert_user(USER_EMAIL, name="Lead")
+    user_manager.save_profile(USER_EMAIL, {
+        "airtable_api_key": "patFakeKey",
+        "servicenow_password": "hunter2",
+        "totp_secret": "JBSWY3DPEHPK3PXP",
+        "preferences": {"auto_booking_enabled": True},
+    })
+
+
+def test_today_persists_as_a_preference():
+    _register()
+    user_manager.update_preferences(USER_EMAIL, {"window_future_days": 0})
+    assert user_manager.get_preferences(USER_EMAIL)["window_future_days"] == 0
+
+
+def test_saving_other_settings_leaves_the_lookahead_alone():
+    """The slider is not in the settings form, so a save must not reset it."""
+    _register()
+    user_manager.update_preferences(USER_EMAIL, {"window_future_days": 7})
+    user_manager.update_preferences(USER_EMAIL, {"buffer_before": 15, "buffer_after": 15})
+    assert user_manager.get_preferences(USER_EMAIL)["window_future_days"] == 7
+
+
+def test_forever_round_trips():
+    _register()
+    user_manager.update_preferences(USER_EMAIL, {"window_future_days": LOOKAHEAD_FOREVER_DAYS})
+    assert user_manager.load_profile(USER_EMAIL)["preferences"]["window_future_days"] == (
+        LOOKAHEAD_FOREVER_DAYS)

--- a/tests/test_manual_booking_email.py
+++ b/tests/test_manual_booking_email.py
@@ -1,0 +1,135 @@
+"""Pressing "Book now" promises an email when the run finishes. It has to arrive.
+
+A scheduled run stays quiet — it reports through the 5pm daily summary instead.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import tasks
+from user_profiles import user_manager
+
+from test_tasks import FakeAirtable, FakeSession, BASE_TIME, USER_EMAIL
+
+
+@pytest.fixture
+def registered_user():
+    user_manager.upsert_user(USER_EMAIL, name="Lead")
+    user_manager.save_profile(USER_EMAIL, {
+        "airtable_api_key": "patFakeKey",
+        "servicenow_password": "hunter2",
+        "totp_secret": "JBSWY3DPEHPK3PXP",
+        "preferences": {"auto_booking_enabled": True},
+    })
+    return USER_EMAIL
+
+
+@pytest.fixture
+def wired(monkeypatch, registered_user):
+    """Record every summary email instead of sending one."""
+    airtable = FakeAirtable()
+    sent = []
+
+    monkeypatch.setattr(tasks, "create_airtable_client", lambda key: airtable)
+    monkeypatch.setattr(tasks, "send_conflict_email", lambda *a, **k: None)
+    monkeypatch.setattr(tasks, "send_booking_summary_email",
+                        lambda to, ok, bad, conflict_sessions=None, manual=False, **k: sent.append({
+                            "to": to, "ok": list(ok), "failed": list(bad),
+                            "conflicts": list(conflict_sessions or []), "manual": manual,
+                        }))
+    monkeypatch.setattr(tasks.gn_ticket, "gn_ticket_handler", lambda send_to_gn, *a, **k: {
+        "successful_sessions": [
+            {"session_id": s.s_id, "title": s.title, "school": s.school,
+             "teacher": s.teacher, "start_time": s.start_time.isoformat(),
+             "length": s.length, "ticket_id": f"TKT-{s.s_id}"}
+            for s in send_to_gn
+        ],
+        "failed_sessions": [],
+    })
+    return {"airtable": airtable, "sent": sent}
+
+
+def test_manual_run_emails_the_person_who_asked(wired):
+    tasks.book_sessions(USER_EMAIL, ["recClean1", "recClean2"], manual=True)
+
+    assert len(wired["sent"]) == 1
+    mail = wired["sent"][0]
+    assert mail["to"] == USER_EMAIL
+    assert mail["manual"] is True
+    assert sorted(entry["ticket_id"] for entry in mail["ok"]) == ["TKT-recClean1", "TKT-recClean2"]
+
+
+def test_scheduled_run_stays_quiet(wired):
+    tasks.book_sessions(USER_EMAIL, ["recClean1", "recClean2"])
+    assert wired["sent"] == []
+
+
+def test_manual_email_lists_conflicts_that_were_skipped(wired):
+    # recConflict overlaps an already-ticketed booking, so it is never sent to GN.
+    tasks.book_sessions(USER_EMAIL, ["recClean1", "recClean2", "recConflict"], manual=True)
+
+    mail = wired["sent"][0]
+    assert [c["session_id"] for c in mail["conflicts"]] == ["recConflict"]
+    assert "recConflict" not in [entry["session_id"] for entry in mail["ok"]]
+
+
+def test_manual_email_still_arrives_when_there_is_nothing_to_book(wired):
+    wired["airtable"]._candidates = lambda: []
+
+    tasks.book_sessions(USER_EMAIL, ["recGone"], manual=True)
+
+    assert len(wired["sent"]) == 1
+    assert wired["sent"][0]["ok"] == []
+    assert wired["sent"][0]["manual"] is True
+
+
+def test_manual_email_reports_a_crash(monkeypatch, wired):
+    def explode(*a, **k):
+        raise RuntimeError("ServiceNow never loaded")
+
+    monkeypatch.setattr(tasks.gn_ticket, "gn_ticket_handler", explode)
+
+    with pytest.raises(RuntimeError):
+        tasks.book_sessions(USER_EMAIL, ["recClean1"], manual=True)
+
+    assert len(wired["sent"]) == 1
+    assert "ServiceNow never loaded" in wired["sent"][0]["failed"][0]["error"]
+
+
+def test_a_pending_request_makes_the_scan_book_manually(monkeypatch, wired):
+    """The dashboard records a request, so the run it triggers must count as manual."""
+    booked = []
+    monkeypatch.setattr(tasks, "dispatch_booking",
+                        lambda email, ids, manual=False: booked.append(manual))
+
+    tasks.request_scan(USER_EMAIL)
+    tasks.scan_user(USER_EMAIL)
+
+    assert booked == [True]
+
+
+def test_a_scan_nobody_asked_for_books_quietly(monkeypatch, wired):
+    booked = []
+    monkeypatch.setattr(tasks, "dispatch_booking",
+                        lambda email, ids, manual=False: booked.append(manual))
+
+    tasks.scan_user(USER_EMAIL)
+
+    assert booked == [False]
+
+
+def test_manual_scan_with_only_conflicts_still_emails(monkeypatch, wired):
+    """Nothing to book, but the button still promised a reply."""
+    wired["airtable"]._candidates = lambda: [
+        FakeSession("recConflict", "Conflicted", "Qiqirtaq School",
+                    BASE_TIME + timedelta(days=2), teacher="Third Teacher"),
+    ]
+
+    tasks.request_scan(USER_EMAIL)
+    tasks.scan_user(USER_EMAIL)
+
+    assert len(wired["sent"]) == 1
+    mail = wired["sent"][0]
+    assert mail["manual"] is True
+    assert mail["ok"] == []
+    assert [c["session_id"] for c in mail["conflicts"]] == ["recConflict"]

--- a/tests/test_session_exclusions.py
+++ b/tests/test_session_exclusions.py
@@ -1,0 +1,152 @@
+"""Removing a session on the dashboard has to stick.
+
+It used to last only until the page reloaded, so a session someone deliberately
+took out came back and was booked by the next scheduled run.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import tasks
+from user_profiles import user_manager
+
+from test_tasks import BASE_TIME, FakeAirtable, FakeSession, USER_EMAIL
+
+
+@pytest.fixture
+def registered_user():
+    user_manager.upsert_user(USER_EMAIL, name="Lead")
+    user_manager.save_profile(USER_EMAIL, {
+        "airtable_api_key": "patFakeKey",
+        "servicenow_password": "hunter2",
+        "totp_secret": "JBSWY3DPEHPK3PXP",
+        "preferences": {"auto_booking_enabled": True},
+    })
+    return USER_EMAIL
+
+
+@pytest.fixture
+def wired(monkeypatch, registered_user):
+    airtable = FakeAirtable()
+    calls = {"booked_ids": [], "airtable": airtable}
+
+    monkeypatch.setattr(tasks, "create_airtable_client", lambda key: airtable)
+    monkeypatch.setattr(tasks, "send_conflict_email", lambda *a, **k: None)
+    monkeypatch.setattr(tasks, "send_booking_summary_email", lambda *a, **k: None)
+    monkeypatch.setattr(tasks, "dispatch_booking",
+                        lambda email, ids, manual=False: calls["booked_ids"].append(list(ids)))
+    return calls
+
+
+def test_removing_and_restoring_round_trips(registered_user):
+    assert tasks.excluded_session_ids(USER_EMAIL) == set()
+
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One",
+                               school="Nakasuk School")
+    assert tasks.excluded_session_ids(USER_EMAIL) == {"recClean1"}
+
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", False)
+    assert tasks.excluded_session_ids(USER_EMAIL) == set()
+
+
+def test_removing_twice_does_not_duplicate(registered_user):
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+
+    assert tasks.excluded_session_ids(USER_EMAIL) == {"recClean1"}
+    assert len(tasks.outstanding_exclusions(USER_EMAIL)) <= 1
+
+
+def test_restoring_something_never_removed_is_harmless(registered_user):
+    assert tasks.set_session_excluded(USER_EMAIL, "recNeverSeen", False) is True
+    assert tasks.excluded_session_ids(USER_EMAIL) == set()
+
+
+def test_a_removed_session_is_not_booked_by_a_scheduled_scan(wired):
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+
+    tasks.scan_user(USER_EMAIL)
+
+    assert wired["booked_ids"] == [["recClean2"]]
+
+
+def test_it_still_is_not_booked_on_the_next_run(wired):
+    """The whole point: this must not come back tomorrow."""
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+
+    tasks.scan_user(USER_EMAIL)
+    tasks.scan_user(USER_EMAIL)
+
+    assert wired["booked_ids"] == [["recClean2"], ["recClean2"]]
+
+
+def test_putting_it_back_lets_it_book_again(wired):
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+    tasks.scan_user(USER_EMAIL)
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", False)
+    tasks.scan_user(USER_EMAIL)
+
+    assert wired["booked_ids"] == [["recClean2"], ["recClean1", "recClean2"]]
+
+
+def test_booking_refuses_a_session_removed_after_the_scan(monkeypatch, wired):
+    """A removal between the scan and the booking run still has to win."""
+    handled = {}
+
+    def fake_handler(send_to_gn, *args, **kwargs):
+        handled["ids"] = [s.s_id for s in send_to_gn]
+        return {"successful_sessions": [], "failed_sessions": []}
+
+    monkeypatch.setattr(tasks.gn_ticket, "gn_ticket_handler", fake_handler)
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+
+    tasks.book_sessions(USER_EMAIL, ["recClean1", "recClean2"])
+
+    assert handled["ids"] == ["recClean2"]
+
+
+def test_a_removed_conflict_stops_being_emailed_about(monkeypatch, wired):
+    emails = []
+    monkeypatch.setattr(tasks, "send_conflict_email",
+                        lambda email, sessions: emails.append(list(sessions)))
+
+    tasks.set_session_excluded(USER_EMAIL, "recConflict", True, title="Conflicted")
+    tasks.scan_user(USER_EMAIL)
+
+    assert emails == []
+
+
+def test_outstanding_exclusions_lists_upcoming_ones(registered_user):
+    start = (BASE_TIME + timedelta(days=3)).replace(tzinfo=None)
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One",
+                               school="Nakasuk School", start_time=start)
+
+    listed = tasks.outstanding_exclusions(USER_EMAIL)
+
+    assert [row["session_id"] for row in listed] == ["recClean1"]
+    assert listed[0]["title"] == "Clean One"
+    assert listed[0]["school"] == "Nakasuk School"
+
+
+def test_exclusions_in_the_past_drop_off_the_list(registered_user):
+    """A session that has happened can never be booked, so it stops being reported."""
+    tasks.set_session_excluded(USER_EMAIL, "recOld", True, title="Last Month",
+                               start_time=datetime.utcnow() - timedelta(days=30))
+
+    assert tasks.outstanding_exclusions(USER_EMAIL) == []
+    # Still excluded, just no longer worth mentioning.
+    assert tasks.excluded_session_ids(USER_EMAIL) == {"recOld"}
+
+
+def test_exclusions_are_per_user(registered_user):
+    other = "colleague@takingitglobal.org"
+    user_manager.upsert_user(other, name="Colleague")
+    user_manager.save_profile(other, {
+        "airtable_api_key": "patOther", "servicenow_password": "x",
+        "totp_secret": "JBSWY3DPEHPK3PXP", "preferences": {},
+    })
+
+    tasks.set_session_excluded(USER_EMAIL, "recClean1", True, title="Clean One")
+
+    assert tasks.excluded_session_ids(USER_EMAIL) == {"recClean1"}
+    assert tasks.excluded_session_ids(other) == set()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -15,7 +15,10 @@ from user_profiles import user_manager
 
 
 USER_EMAIL = "lead@takingitglobal.org"
-BASE_TIME = datetime(2026, 9, 15, 15, 0, tzinfo=timezone.utc)
+# Relative to now, not a fixed date: candidates have to stay comfortably outside the
+# last-minute window, and a hardcoded date silently walks into it as time passes.
+BASE_TIME = (datetime.now(timezone.utc) + timedelta(days=30)).replace(
+    hour=15, minute=0, second=0, microsecond=0)
 
 
 class FakeSession:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -90,13 +90,15 @@ def registered_user():
 def wired(monkeypatch, registered_user):
     """Patch out Airtable, email and the booking queue; record what each was asked to do."""
     airtable = FakeAirtable()
-    calls = {"booked_ids": [], "conflict_emails": []}
+    calls = {"booked_ids": [], "conflict_emails": [], "manual_flags": []}
 
     monkeypatch.setattr(tasks, "create_airtable_client", lambda key: airtable)
     monkeypatch.setattr(tasks, "send_conflict_email",
                         lambda email, sessions: calls["conflict_emails"].append(list(sessions)))
     monkeypatch.setattr(tasks.book_sessions, "delay",
-                        lambda email, ids: calls["booked_ids"].append(list(ids)))
+                        lambda email, ids, manual=False: (
+                            calls["booked_ids"].append(list(ids)),
+                            calls["manual_flags"].append(manual)))
     calls["airtable"] = airtable
     return calls
 

--- a/tests/test_ticket_submission_log.py
+++ b/tests/test_ticket_submission_log.py
@@ -120,7 +120,10 @@ def test_conflict_detection_flags_ghost_ticket_overlap():
         }
     ]
 
-    result = check_for_time_conflicts([candidate], [], historical_entries)
+    # Pin the clock well before the session, or the last-minute rule claims it first
+    # and this stops testing ghost-ticket detection at all.
+    result = check_for_time_conflicts([candidate], [], historical_entries,
+                                      now=start - timedelta(days=30))
     assert result[0].is_conflict is True
     assert result[0].conflict_type == 'ghost_ticket'
     assert 'Rebooked/ghost ticket' in result[0].conflict_details

--- a/user_profiles.py
+++ b/user_profiles.py
@@ -29,6 +29,41 @@ def normalize_scan_frequency(value):
     return hours if hours in SCAN_FREQUENCY_CHOICES else DEFAULT_SCAN_FREQUENCY_HOURS
 
 
+# How far ahead the dashboard looks for candidate sessions. These are the labelled
+# stops on the slider, so the value is always one of them rather than any integer.
+# "Forever" is a decade rather than an unbounded query: Airtable still wants a date,
+# and nothing is booked ten years out.
+LOOKAHEAD_FOREVER_DAYS = 3650
+LOOKAHEAD_STOPS = (
+    (0, "Today"),
+    (7, "7 days"),
+    (10, "10 days"),
+    (14, "14 days"),
+    (30, "30 days"),
+    (60, "60 days"),
+    (90, "90 days"),
+    (LOOKAHEAD_FOREVER_DAYS, "Forever"),
+)
+LOOKAHEAD_DAYS = tuple(days for days, _ in LOOKAHEAD_STOPS)
+DEFAULT_LOOKAHEAD_DAYS = 90
+
+
+def normalize_lookahead(value):
+    """Snap whatever arrived from the slider onto the nearest offered stop."""
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_LOOKAHEAD_DAYS
+    if days in LOOKAHEAD_DAYS:
+        return days
+    # A value from an older preference row, or a hand-edited query string. Round up to
+    # the first stop that still covers it so nothing silently drops out of view.
+    for stop in LOOKAHEAD_DAYS:
+        if days <= stop:
+            return stop
+    return LOOKAHEAD_FOREVER_DAYS
+
+
 def _get_fernet():
     key = os.getenv("APP_ENCRYPTION_KEY", "").strip()
     if not key:
@@ -111,7 +146,8 @@ class UserProfileManager:
         if "window_past_days" in prefs:
             preferences.window_past_days = int(prefs.get("window_past_days") or preferences.window_past_days)
         if "window_future_days" in prefs:
-            preferences.window_future_days = int(prefs.get("window_future_days") or preferences.window_future_days)
+            # Not the `or` fallback used above: "Today" is 0, which is falsy but real.
+            preferences.window_future_days = normalize_lookahead(prefs.get("window_future_days"))
         preferences.updated_at = datetime.utcnow()
 
     def load_profile(self, email):
@@ -136,7 +172,8 @@ class UserProfileManager:
                     "auto_booking_enabled": prefs.auto_booking_enabled if prefs else False,
                     "scan_frequency_hours": (prefs.scan_frequency_hours if prefs else None) or DEFAULT_SCAN_FREQUENCY_HOURS,
                     "window_past_days": prefs.window_past_days if prefs else 14,
-                    "window_future_days": prefs.window_future_days if prefs else 90,
+                    "window_future_days": normalize_lookahead(
+                        prefs.window_future_days if prefs else DEFAULT_LOOKAHEAD_DAYS),
                 }
             }
 
@@ -154,7 +191,7 @@ class UserProfileManager:
                     "auto_booking_enabled": False,
                     "scan_frequency_hours": DEFAULT_SCAN_FREQUENCY_HOURS,
                     "window_past_days": 14,
-                    "window_future_days": 90,
+                    "window_future_days": DEFAULT_LOOKAHEAD_DAYS,
                 }
             return {
                 "buffer_before": prefs.buffer_before,
@@ -162,7 +199,7 @@ class UserProfileManager:
                 "auto_booking_enabled": prefs.auto_booking_enabled,
                 "scan_frequency_hours": prefs.scan_frequency_hours or DEFAULT_SCAN_FREQUENCY_HOURS,
                 "window_past_days": prefs.window_past_days,
-                "window_future_days": prefs.window_future_days,
+                "window_future_days": normalize_lookahead(prefs.window_future_days),
             }
 
     def update_preferences(self, email, prefs):


### PR DESCRIPTION
Six dashboard/behaviour changes plus a blueprint change. **Touches booking logic and the database, so this wants a review rather than a direct merge.**

**168 tests pass**, up from 122 on `main`.

---

## Booking correctness

### "Remove" now sticks *(new table)*
It only flipped a hidden input, so it lasted until the page reloaded — a session deliberately taken off the list came back and was booked by the next scheduled run. It is now a row in `session_exclusions`, standing until you put it back with "Process anyway".

Honoured in three places: the scan, the booking run, and the in-process desktop path. The booking run re-reads candidates, so a removal can land between scan and booking and still has to win. Removed sessions also stop being emailed about as conflicts — the decision has been made.

Flagged in the daily summary under **REMOVED, NOT BEING BOOKED**, so something held back indefinitely stays visible instead of silently never happening. Only upcoming ones are listed; a past session can never be booked again and would otherwise grow the email forever.

If the save fails, the button reverts rather than leaving the page implying the removal was stored.

### Last-minute sessions are held back
Anything starting within **12 hours** is treated like a conflict: not booked, reported in the same category. Checked *before* every other rule — there is no point working out who to email about a clash for something happening this afternoon. `GN_LAST_MINUTE_HOURS` tunes it, `0` disables it, and it can still be booked by hand.

---

## Dashboard

### Look-ahead slider
Replaces the number box in settings: Today / 7 / 10 / 14 / 30 / 60 / 90 days / Forever, above the candidates. Narrowing filters client-side; widening past the loaded window reloads with `?future_days=N` and re-pulls from Airtable.

Hidden sessions are also **deselected**, so narrowing the view narrows what "Book now" books rather than filing tickets for sessions off screen.

Two bugs found on the way:
- "Today" is `0`, and the preference writer used `int(value or previous)` — Today could never be saved.
- With the field gone from the settings form, "Save settings" would have reset the slider to the default.

### "Book now" reports by email
The button says the run started and mail will follow, and it now actually sends — booked, failed, and conflict-skipped — on every exit path including nothing-bookable, browser-slot-busy, and crashed. A pending `ScanRequest` marks a run as manual, so the hosted path reports even though the cron job does the work. Scheduled runs stay quiet and report via the 5pm summary.

### Readable timestamps
"Last automatic run" showed `2026-08-20T00:36:32.382565`; now `Wed, Aug 19 at 8:36 pm`. Applied across the emails too — otherwise one email mixed both formats.

---

## Database: 1 GB, still paid

`diskSizeGB: 1` — $0.30/month of storage instead of the $4.50 that 15 GB costs.

**Deliberately not the `free` instance type.** Free Postgres expires 30 days after creation, is deleted after a 14-day grace period, and cannot be upgraded to paid. This database holds every user's encrypted Airtable key, ServiceNow password and 2FA secret. Compute is identical either way (256 MB / 0.1 CPU).

Render can only *grow* a disk, so **this does not resize the live database** — that needs a new 1 GB database and a repointed `DATABASE_URL`.

---

## Notes

- `session_exclusions` is a **new table**, so `create_all` handles it. No `ensure_column` migration needed.
- Two test fixtures used hardcoded dates that were future when written and had gone stale — one had already drifted into the last-minute window and was silently testing the wrong branch. Both are now relative to the clock.
- Already done on `main`, no change needed here: the single "Book now" button (only the copy changed) and the 5pm daily summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
