### PR TITLE
Declare DATABASE_URL once instead of per service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,6 +13,25 @@ envVarGroups:
       # Generate once; losing it means every user redoes the setup wizard.
       - key: APP_ENCRYPTION_KEY
         generateValue: true
+      # The database is created and managed by hand rather than by this blueprint, so
+      # the URL is set in the dashboard. It lives in the shared group, not on each
+      # service, because it was previously declared twice — and repointing at a new
+      # database updated one of them and left the cron job talking to a host that no
+      # longer resolved. One declaration cannot drift from itself.
+      #
+      # Use the database's INTERNAL URL: both services run on Render, and internal
+      # traffic stays on the private network instead of the public internet. It
+      # requires the database to be in the same account and region as the services.
+      #
+      # The database itself: a paid instance with 1 GB of storage. Storage bills at
+      # $0.30/GB/month, and this only ever holds text — users, tickets, scan results,
+      # sessions — so the 15 GB it was originally built with cost $4.50/month for
+      # nothing. Deliberately NOT the free instance type: free Postgres expires 30
+      # days after creation and cannot be upgraded, and this holds every user's
+      # encrypted Airtable key, ServiceNow password and 2FA secret. Compute is the
+      # same 256 MB / 0.1 CPU either way.
+      - key: DATABASE_URL
+        sync: false
       - key: GN_INLINE_TASKS
         value: "1"
       - key: AUTO_SCAN_TZ
@@ -50,10 +69,6 @@ services:
     healthCheckPath: /
     envVars:
       - fromGroup: gn-ticket-shared
-      - key: DATABASE_URL
-        fromDatabase:
-          name: gn-ticket-db
-          property: connectionString
       - key: DISABLE_UPDATES
         value: "1"
       # Manual booking drives Chrome in this process, which 512 MB cannot survive.
@@ -89,26 +104,3 @@ services:
     dockerCommand: python run_scan.py
     envVars:
       - fromGroup: gn-ticket-shared
-      - key: DATABASE_URL
-        fromDatabase:
-          name: gn-ticket-db
-          property: connectionString
-
-databases:
-  - name: gn-ticket-db
-    # Not `free`: a free Postgres expires 30 days after creation and is then deleted,
-    # and it cannot be upgraded to a paid instance. This database holds every user's
-    # encrypted Airtable key, ServiceNow password and 2FA secret — losing it monthly
-    # would mean everyone redoing the setup wizard. basic-256mb is the same 256 MB /
-    # 0.1 CPU as free, and only the storage was ever oversized.
-    plan: basic-256mb
-    # 1 GB, the smallest there is. This stores text: users, tickets, scan results and
-    # sessions. Storage bills at $0.30/GB/month, so this is $0.30 rather than the
-    # $4.50 that 15 GB costs.
-    #
-    # Render can only ever GROW a database's disk — "you can increase an existing
-    # database's storage at any time, but you can't reduce it". So this line does not
-    # shrink the live database; it only applies to one created fresh. Shrinking means
-    # creating a new database and repointing DATABASE_URL.
-    diskSizeGB: 1
-    databaseName: gn_ticket


### PR DESCRIPTION
Config only — no application code, no schema. Follows the cron failure after repointing to the new database.

`DATABASE_URL` was declared twice, once per service, both via `fromDatabase` against the blueprint-managed `gn-ticket-db`. Repointing at the hand-created database updated the web service and left `gn-ticket-scan` holding the old internal hostname, which stopped resolving once the old database was gone — every run died with `could not translate host name`.

It is now declared once in the `gn-ticket-shared` group as `sync: false`, so both services inherit one value and this cannot drift again.

The `databases:` block is removed too: the blueprint no longer creates the database, and a stale `gn-ticket-db` entry would have it managing something that is not the live one. The sizing rationale it carried (1 GB, paid rather than free because free Postgres expires after 30 days) moves into the `DATABASE_URL` comment, along with a note to use the internal URL and why.

**This does not fix the running cron job** — the value still has to be set on `gn-ticket-scan` in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)