### PR TITLE
Say plainly that the sync:false entries are set by hand

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,8 +13,15 @@ envVarGroups:
       # Generate once; losing it means every user redoes the setup wizard.
       - key: APP_ENCRYPTION_KEY
         generateValue: true
+      # NOTE: this entry does not create anything. Render only prompts for sync:false
+      # values during initial Blueprint creation and ignores them on later syncs, and
+      # it ignores sync:false inside envVarGroups entirely — the same is true of the
+      # SMTP_* and CHATGPT_API_KEY entries below. Every one of these has to be added
+      # to the gn-ticket-shared group by hand in the dashboard. They are listed here
+      # so the blueprint still records what the services need in order to run.
+      #
       # The database is created and managed by hand rather than by this blueprint, so
-      # the URL is set in the dashboard. It lives in the shared group, not on each
+      # the URL is set in the dashboard. It belongs in the shared group, not on each
       # service, because it was previously declared twice — and repointing at a new
       # database updated one of them and left the cron job talking to a host that no
       # longer resolved. One declaration cannot drift from itself.


### PR DESCRIPTION
Comment-only correction to the previous config commit. No behaviour change.

The last commit implied that declaring `DATABASE_URL` in `gn-ticket-shared` would create the key. It does not — Render only prompts for `sync: false` values during *initial* Blueprint creation, ignores them on later syncs, and per the blueprint spec ignores `sync: false` inside `envVarGroups` entirely.

The pre-existing `SMTP_*` and `CHATGPT_API_KEY` entries are in the same shape and have only ever worked because they were entered in the dashboard. The comment now says so, rather than leaving the next person to rediscover it during an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)