### PR TITLE
Make the look-ahead slider a saved preference the scheduled run obeys

### DIFF
--- a/airtable_integration.py
+++ b/airtable_integration.py
@@ -10,6 +10,18 @@ logger = logging.getLogger(__name__)
 REQUEST_TIMEOUT = int(os.getenv("REQUESTS_TIMEOUT", "15"))
 
 
+def future_cutoff(window_future_days):
+    """Airtable expression for the far edge of the look-ahead window.
+
+    DATEADD(TODAY(), N, 'day') is midnight at the *start* of day N, so comparing
+    against it stops at the end of day N-1. The look-ahead slider means "through
+    the end of day N", which the dashboard's own filtering already assumes — most
+    visibly at its first stop, "Today" (0 days), where the previous formula matched
+    nothing at all instead of the rest of today.
+    """
+    return f"DATEADD(TODAY(), {int(window_future_days) + 1}, 'day')"
+
+
 class AirtableSession:
     """Represents a session from Airtable"""
 
@@ -203,7 +215,7 @@ class AirtableIntegration:
                 # conflict lookups, which do need to see backwards.
                 filter_parts.append("IS_AFTER({Session Start Date/Time}, NOW())")
                 filter_parts.append(
-                    f"IS_BEFORE({{Session Start Date/Time}}, DATEADD(TODAY(), {int(window_future_days)}, 'day'))"
+                    f"IS_BEFORE({{Session Start Date/Time}}, {future_cutoff(window_future_days)})"
                 )
 
                 # ADDED: Exclude sessions where GN Ticket has already been requested
@@ -327,7 +339,7 @@ class AirtableIntegration:
                 f"IS_AFTER({{Session Start Date/Time}}, DATEADD(TODAY(), -{int(window_past_days)}, 'day'))"
             )
             filter_parts.append(
-                f"IS_BEFORE({{Session Start Date/Time}}, DATEADD(TODAY(), {int(window_future_days)}, 'day'))"
+                f"IS_BEFORE({{Session Start Date/Time}}, {future_cutoff(window_future_days)})"
             )
 
             # Combine filters

--- a/main.py
+++ b/main.py
@@ -708,6 +708,30 @@ def set_session_excluded_route():
         return jsonify({'ok': False, 'error': str(e)}), 500
 
 
+@app.route("/gn_ticket/set_lookahead", methods=["POST"])
+@require_auth
+def set_lookahead_route():
+    """Save the look-ahead slider. It is a preference, not a view setting: the
+    scheduled run reads the same window, so moving the slider also decides how far
+    ahead auto-booking reaches."""
+    user = session['user']
+    data = request.get_json(silent=True) or {}
+    if 'window_future_days' not in data:
+        return jsonify({'ok': False, 'error': 'missing window_future_days'}), 400
+
+    window_future_days = normalize_lookahead(data.get('window_future_days'))
+    try:
+        user_manager.update_preferences(user['email'],
+                                        {'window_future_days': window_future_days})
+    except Exception as e:
+        logging.error(f"set_lookahead error: {e}", exc_info=True)
+        return jsonify({'ok': False, 'error': str(e)}), 500
+
+    label = next((lbl for days, lbl in LOOKAHEAD_STOPS if days == window_future_days),
+                 str(window_future_days))
+    return jsonify({'ok': True, 'window_future_days': window_future_days, 'label': label})
+
+
 @app.route("/progress/<session_id>")
 @require_auth
 def stream_session_progress(session_id):

--- a/templates/gn.html
+++ b/templates/gn.html
@@ -203,6 +203,11 @@ body {
   color: #2c7be5;
   font-weight: bold;
 }
+.lookahead-error {
+  margin-top: 4px;
+  font-size: 0.85em;
+  color: #b3261e;
+}
 .lookahead-note {
   margin-top: 8px;
   font-size: 0.85rem;
@@ -328,6 +333,8 @@ function showExclusionError(sessionDiv, btn, attempted) {
 // Narrowing the window hides cards that are already on the page. Widening it past
 // the window this page was built with needs sessions the server never sent, so that
 // reloads with ?future_days=N and Airtable is queried again.
+// Either way the chosen stop is saved as a preference, because the scheduled run
+// books against the same window: the slider decides how far ahead it reaches.
 // This script block lives in <head>, so wait for the cards to exist.
 document.addEventListener('DOMContentLoaded', function () {
   var range = document.getElementById('lookahead-range');
@@ -339,6 +346,8 @@ document.addEventListener('DOMContentLoaded', function () {
   var loadedDays = parseInt(range.dataset.loadedDays, 10);
   var valueLabel = document.getElementById('lookahead-value');
   var note = document.getElementById('lookahead-note');
+  var saveError = document.getElementById('lookahead-error');
+  var savedLabel = valueLabel.textContent.trim();
 
   // End of the chosen day, local time, so "Today" keeps everything later today.
   function cutoffFor(days) {
@@ -389,6 +398,24 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  // Save the stop so it survives a reload and so the scheduled run books against
+  // the same window. Widening reloads with ?future_days=N, which the server saves
+  // as it rebuilds the page, so only the client-side narrowing needs this call.
+  function persist(days) {
+    return fetch('/gn_ticket/set_lookahead', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ window_future_days: days })
+    }).then(function (res) {
+      if (!res.ok) throw new Error('save failed');
+      return res.json();
+    }).then(function (res) {
+      if (!res || !res.ok) throw new Error('save failed');
+      return res;
+    });
+  }
+
   function onChange() {
     var stop = stops[parseInt(range.value, 10)];
     if (!stop) return;
@@ -396,7 +423,7 @@ document.addEventListener('DOMContentLoaded', function () {
     markActive(stops.indexOf(stop));
 
     if (stop.days > loadedDays) {
-      // Beyond what this page loaded — go get the rest.
+      // Beyond what this page loaded — go get the rest. The reload saves it.
       note.textContent = 'Loading sessions further ahead…';
       var url = new URL(window.location.href);
       url.searchParams.set('future_days', stop.days);
@@ -404,6 +431,14 @@ document.addEventListener('DOMContentLoaded', function () {
       return;
     }
     applyFilter(stop.days);
+    persist(stop.days).then(function (res) {
+      savedLabel = (res && res.label) || stop.label;
+      saveError.textContent = '';
+    }).catch(function () {
+      // Say so rather than letting the page imply the scheduled run was narrowed too.
+      saveError.textContent = 'Could not save that — scheduled runs still use ' +
+        savedLabel + ' and this resets when you reload.';
+    });
   }
 
   range.addEventListener('input', function () {
@@ -667,6 +702,9 @@ document.addEventListener('DOMContentLoaded', function() {
         {% endfor %}
       </div>
       <div class="lookahead-note" id="lookahead-note"></div>
+      <div class="lookahead-note">Saved automatically. Scheduled runs only auto-book
+        sessions inside this window.</div>
+      <div class="lookahead-error" id="lookahead-error"></div>
     </div>
 
     <!-- Session Gallery Section -->

--- a/tests/test_forward_only_candidates.py
+++ b/tests/test_forward_only_candidates.py
@@ -53,12 +53,35 @@ def test_candidates_do_not_reach_into_the_past(monkeypatch):
 
 
 def test_the_forward_window_still_applies(monkeypatch):
+    """90 days means through the end of the 90th day, so the cutoff is day 91."""
     client = AirtableIntegration("patTest")
 
     formula = capture_filter(monkeypatch, lambda: client.get_booked_sessions(
         user_email="lead@takingitglobal.org", window_past_days=14, window_future_days=90))
 
-    assert "DATEADD(TODAY(), 90, 'day')" in formula
+    assert "DATEADD(TODAY(), 91, 'day')" in formula
+
+
+def test_today_still_matches_the_rest_of_today(monkeypatch):
+    """The regression: a 0 day window asked for sessions before this morning, so the
+    "Today" stop found nothing and the scheduled run booked nothing."""
+    client = AirtableIntegration("patTest")
+
+    formula = capture_filter(monkeypatch, lambda: client.get_booked_sessions(
+        user_email="lead@takingitglobal.org", window_past_days=14, window_future_days=0))
+
+    assert "DATEADD(TODAY(), 1, 'day')" in formula
+    assert "DATEADD(TODAY(), 0, 'day')" not in formula
+
+
+def test_the_conflict_lookup_uses_the_same_horizon(monkeypatch):
+    client = AirtableIntegration("patTest")
+
+    formula = capture_filter(monkeypatch, lambda: client.get_all_sessions_for_schools(
+        ["Nakasuk School"], status_filters=["Booked"], window_past_days=14,
+        window_future_days=0))
+
+    assert "DATEADD(TODAY(), 1, 'day')" in formula
 
 
 def test_conflict_lookups_still_look_backwards(monkeypatch):

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -70,3 +70,108 @@ def test_forever_round_trips():
     user_manager.update_preferences(USER_EMAIL, {"window_future_days": LOOKAHEAD_FOREVER_DAYS})
     assert user_manager.load_profile(USER_EMAIL)["preferences"]["window_future_days"] == (
         LOOKAHEAD_FOREVER_DAYS)
+
+
+# --- Saving the slider ------------------------------------------------------
+# Narrowing the window is filtered in the browser, so nothing reaches the server
+# unless the page asks it to. Without that the choice was lost on the next load —
+# and the scheduled run, which reads the same preference, never narrowed at all.
+
+
+@pytest.fixture
+def client():
+    import main
+
+    main.app.config["TESTING"] = True
+    main.app.secret_key = "test-secret"
+    test_client = main.app.test_client()
+    with test_client.session_transaction() as flask_session:
+        flask_session["user"] = {"email": USER_EMAIL, "name": "Lead"}
+    return test_client
+
+
+def test_narrowing_the_slider_is_saved(client):
+    _register()
+
+    response = client.post("/gn_ticket/set_lookahead", json={"window_future_days": 7})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "window_future_days": 7, "label": "7 days"}
+    assert user_manager.get_preferences(USER_EMAIL)["window_future_days"] == 7
+
+
+def test_today_is_saved_rather_than_read_as_missing(client):
+    _register()
+
+    response = client.post("/gn_ticket/set_lookahead", json={"window_future_days": 0})
+
+    assert response.get_json()["label"] == "Today"
+    assert user_manager.get_preferences(USER_EMAIL)["window_future_days"] == 0
+
+
+def test_a_value_off_the_scale_snaps_to_a_stop(client):
+    _register()
+
+    response = client.post("/gn_ticket/set_lookahead", json={"window_future_days": 45})
+
+    assert response.get_json()["window_future_days"] == 60
+    assert user_manager.get_preferences(USER_EMAIL)["window_future_days"] == 60
+
+
+def test_a_request_without_the_field_changes_nothing(client):
+    _register()
+    user_manager.update_preferences(USER_EMAIL, {"window_future_days": 14})
+
+    response = client.post("/gn_ticket/set_lookahead", json={})
+
+    assert response.status_code == 400
+    assert user_manager.get_preferences(USER_EMAIL)["window_future_days"] == 14
+
+
+# --- The scheduled run reads the same window --------------------------------
+
+
+class WindowRecordingAirtable:
+    """Remembers the horizon each query was given, and returns nothing."""
+
+    def __init__(self):
+        self.windows = []
+
+    def get_booked_sessions(self, user_email=None, window_past_days=14, window_future_days=90):
+        self.windows.append(window_future_days)
+        return []
+
+    def get_all_sessions_for_schools(self, school_names, status_filters=None,
+                                     window_past_days=14, window_future_days=90):
+        self.windows.append(window_future_days)
+        return []
+
+
+def test_the_scheduled_scan_uses_the_saved_lookahead(monkeypatch):
+    import tasks
+
+    _register()
+    user_manager.update_preferences(USER_EMAIL, {"window_future_days": 7})
+
+    airtable = WindowRecordingAirtable()
+    monkeypatch.setattr(tasks, "create_airtable_client", lambda key: airtable)
+
+    tasks.scan_user(USER_EMAIL)
+
+    assert airtable.windows == [7]
+
+
+def test_the_booking_pass_uses_the_saved_lookahead(monkeypatch):
+    """The re-read before booking has to honour a window narrowed since the scan."""
+    import tasks
+
+    _register()
+    user_manager.update_preferences(USER_EMAIL, {"window_future_days": 0})
+
+    airtable = WindowRecordingAirtable()
+    monkeypatch.setattr(tasks, "create_airtable_client", lambda key: airtable)
+    monkeypatch.setattr(tasks, "DRY_RUN", True)
+
+    tasks.book_sessions(USER_EMAIL, ["recSomething"])
+
+    assert airtable.windows == [0]


### PR DESCRIPTION
Narrowing the look-ahead window was filtered in the browser and never reached the server, so the choice was lost on the next load — and the scheduled run, which reads the same preference, kept booking out to the old horizon. Only widening persisted, as a side effect of reloading with `?future_days=N`.

## Changes

- **`main.py`** — new `POST /gn_ticket/set_lookahead` (JSON, `@require_auth`, same shape as the existing `set_excluded` endpoint). Values go through `normalize_lookahead`, so "Today" (0, falsy) survives and off-scale values snap to a stop.
- **`templates/gn.html`** — the slider persists every stop it settles on. Widening still reloads (the reload saves it); narrowing POSTs. A failed save says so and names the horizon the scheduled run is still using, rather than implying the scheduled run was narrowed too. Added a standing line under the slider: scheduled runs only auto-book inside this window.
- **`airtable_integration.py`** — new `future_cutoff()` helper fixing an off-by-one in both query builders. `DATEADD(TODAY(), N, 'day')` is midnight at the *start* of day N, so the filter stopped at the end of day N-1. At the "Today" stop that asked for sessions before this morning, which combined with `IS_AFTER(..., NOW())` matched nothing — so picking "Today" would have auto-booked nothing at all. The horizon now runs through the end of day N, matching what the browser-side filtering already assumed.

The scheduled run itself needed no change: `tasks.py` already reads `window_future_days` from the user's preferences for both the scan and the re-read before booking. The preference just never got written.

## Tests

8 new tests, all in `tests/test_lookahead.py` and `tests/test_forward_only_candidates.py`:

- the save endpoint: narrowing, "Today", off-scale snapping, and a request without the field changing nothing
- the scheduled scan and the pre-booking re-read both querying Airtable with the saved horizon
- the day-0 window matching the rest of today
- updated `test_the_forward_window_still_applies` for the corrected cutoff (90 days → day 91)

Full suite: 176 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hf2sLDQ4513BgdhXfd6wbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf2sLDQ4513BgdhXfd6wbU)_