### PR TITLE
Show every time in Edmonton, marked with its zone

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -5,15 +5,25 @@ from email.message import EmailMessage
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # Timestamps are stored as naive UTC but read by people in one place, so anything
-# shown on a page or in an email is rendered in this zone.
-DISPLAY_TZ = os.getenv("AUTO_SCAN_TZ", "America/Toronto")
+# shown on a page or in an email is rendered in this zone. Deliberately its own
+# setting rather than AUTO_SCAN_TZ: that one says when the scheduled scan fires,
+# and the two answer different questions. Everyone reading this today is in
+# Edmonton; when that stops being true this becomes a per-user preference.
+DISPLAY_TZ = os.getenv("DISPLAY_TZ", "America/Edmonton")
 
 
-def friendly_datetime(value, fallback="unknown"):
-    """Render a timestamp as 'Wed, Aug 19 at 8:36 pm' in the display timezone.
+def display_timezone_label():
+    """Name the display zone as a person would: 'Edmonton' from 'America/Edmonton'."""
+    return DISPLAY_TZ.rsplit("/", 1)[-1].replace("_", " ")
+
+
+def friendly_datetime(value, fallback="unknown", tz=None):
+    """Render a timestamp as 'Wed, Aug 19 at 8:36 pm MDT' in the display timezone.
 
     Accepts an ISO string or a datetime. A naive value is taken as UTC, which is how
-    every timestamp in this app is stored.
+    every timestamp in this app is stored. The zone abbreviation is always shown, so
+    a time is never ambiguous to a reader somewhere else. Pass `tz` to render in a
+    zone other than the default display one.
     """
     if not value:
         return fallback
@@ -31,7 +41,7 @@ def friendly_datetime(value, fallback="unknown"):
         moment = moment.replace(tzinfo=timezone.utc)
 
     try:
-        local = moment.astimezone(ZoneInfo(DISPLAY_TZ))
+        local = moment.astimezone(ZoneInfo(tz or DISPLAY_TZ))
     except ZoneInfoNotFoundError:
         local = moment.astimezone(timezone.utc)
 
@@ -39,7 +49,8 @@ def friendly_datetime(value, fallback="unknown"):
     day = str(local.day)
     hour = str((local.hour % 12) or 12)
     meridiem = "am" if local.hour < 12 else "pm"
-    return f"{local:%a}, {local:%b} {day} at {hour}:{local:%M} {meridiem}"
+    zone = local.tzname() or ""
+    return f"{local:%a}, {local:%b} {day} at {hour}:{local:%M} {meridiem} {zone}".strip()
 
 
 def _send(to_email, subject, body):
@@ -159,7 +170,8 @@ def send_daily_summary_email(to_email, booked_sessions, conflict_sessions, summa
     conflict_sessions = conflict_sessions or []
     excluded_sessions = excluded_sessions or []
 
-    lines = [f"GN ticket summary for {summary_date}.", ""]
+    lines = [f"GN ticket summary for {summary_date}.",
+             f"All times below are {display_timezone_label()} time.", ""]
 
     if booked_sessions:
         lines.append(f"BOOKED TODAY ({len(booked_sessions)})")

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ from ticket_submission_log import TicketSubmissionLog
 from google_auth_oauthlib.flow import Flow
 from collections import deque
 from conflict import check_for_time_conflicts
-from emailer import friendly_datetime, send_booking_summary_email
+from emailer import DISPLAY_TZ, friendly_datetime, send_booking_summary_email
 from db import DATABASE_URL, SessionLocal
 from models import ScanResult, User, ConflictEmailLog
 import tasks
@@ -171,6 +171,9 @@ app.config['SESSION_CLEANUP_N_REQUESTS'] = 200
 Session(app)
 
 app.jinja_env.filters['friendly_datetime'] = friendly_datetime
+# The pages re-render times in the browser, so the templates need the same zone the
+# server-rendered ones use — otherwise the two disagree on a machine set elsewhere.
+app.jinja_env.globals['display_timezone'] = DISPLAY_TZ
 
 
 def notify_booking_finished(user_email, successful, failed, conflicts=None):

--- a/render.yaml
+++ b/render.yaml
@@ -43,6 +43,11 @@ envVarGroups:
         value: "1"
       - key: AUTO_SCAN_TZ
         value: America/Toronto
+      # The zone every time is shown in, on the pages and in the emails, marked with
+      # its abbreviation so it is never ambiguous. Separate from AUTO_SCAN_TZ, which
+      # only says when the scheduled scan fires.
+      - key: DISPLAY_TZ
+        value: America/Edmonton
       # End-of-day summary: the first hourly run at or after this local hour sends it.
       - key: DAILY_SUMMARY_HOUR
         value: "17"

--- a/templates/gn.html
+++ b/templates/gn.html
@@ -491,6 +491,10 @@ function openConflictEmail(btn) {
   btn.replaceWith(badge);
 }
 
+// Every time on this page is shown in one zone, marked with its abbreviation, so
+// nobody has to know where the browser they opened it in happens to be.
+const DISPLAY_TIMEZONE = '{{ display_timezone }}';
+
 document.addEventListener('DOMContentLoaded', function() {
   const timeElements = document.querySelectorAll('.session-time[data-time]');
   timeElements.forEach(function(element) {
@@ -500,7 +504,8 @@ document.addEventListener('DOMContentLoaded', function() {
     if (isNaN(parsedDate.getTime())) return;
     const formatted = new Intl.DateTimeFormat([], {
       year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: 'numeric', minute: '2-digit', hour12: true, timeZoneName: 'short'
+      hour: 'numeric', minute: '2-digit', hour12: true,
+      timeZone: DISPLAY_TIMEZONE, timeZoneName: 'short'
     }).format(parsedDate);
     element.textContent = formatted;
   });
@@ -515,10 +520,12 @@ document.addEventListener('DOMContentLoaded', function() {
     if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return;
     const startFormatted = new Intl.DateTimeFormat([], {
       month: 'short', day: '2-digit',
-      hour: 'numeric', minute: '2-digit', hour12: true, timeZoneName: 'short'
+      hour: 'numeric', minute: '2-digit', hour12: true,
+      timeZone: DISPLAY_TIMEZONE, timeZoneName: 'short'
     }).format(startDate);
     const endFormatted = new Intl.DateTimeFormat([], {
-      hour: 'numeric', minute: '2-digit', hour12: true, timeZoneName: 'short'
+      hour: 'numeric', minute: '2-digit', hour12: true,
+      timeZone: DISPLAY_TIMEZONE, timeZoneName: 'short'
     }).format(endDate);
     element.textContent = ` (${startFormatted} – ${endFormatted}).`;
   });
@@ -600,7 +607,7 @@ document.addEventListener('DOMContentLoaded', function() {
       {% if booking_busy_since %}
       <div style="margin-top: 12px; padding: 10px 12px; background: #fff6e0; border: 1px solid #e6c682; border-radius: 4px; font-size: 0.9em;">
         <strong>A booking run is in progress.</strong>
-        Started {{ booking_busy_since.strftime('%H:%M') }} UTC. Only one runs at a time —
+        Started {{ booking_busy_since | friendly_datetime }}. Only one runs at a time —
         if you start another it will wait its turn rather than fail.
       </div>
       {% endif %}
@@ -731,7 +738,7 @@ document.addEventListener('DOMContentLoaded', function() {
           </div>
 
           <div class="session-meta">
-            <span class="session-time" data-time="{{ session.start_time.isoformat() if session.start_time else '' }}">{{ session.start_time.strftime('%Y-%m-%d %I:%M %p') if session.start_time else 'Not set' }}</span>
+            <span class="session-time" data-time="{{ session.start_time.isoformat() if session.start_time else '' }}">{{ session.start_time | friendly_datetime('Not set') }}</span>
             · {{ session.length }} min
             · {% if session.zoom_link and session.zoom_link.strip() %}<span class="status-good">✅ Zoom</span>{% else %}<span class="status-bad">❌ No Zoom</span>{% endif %}
           </div>
@@ -768,10 +775,10 @@ document.addEventListener('DOMContentLoaded', function() {
             <td>{{ entry.title }}</td>
             <td>{{ entry.school }}</td>
             <td>
-              <span class="session-time" data-time="{{ entry.start_time or '' }}">{{ entry.start_time or 'Unknown' }}</span>
+              <span class="session-time" data-time="{{ entry.start_time or '' }}">{{ entry.start_time | friendly_datetime('Unknown') }}</span>
             </td>
             <td>
-              <span class="session-time" data-time="{{ entry.submitted_at or '' }}">{{ entry.submitted_at or 'Unknown' }}</span>
+              <span class="session-time" data-time="{{ entry.submitted_at or '' }}">{{ entry.submitted_at | friendly_datetime('Unknown') }}</span>
             </td>
           </tr>
           {% endfor %}
@@ -800,7 +807,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <td>{{ entry.title }}</td>
             <td>{{ entry.school }}</td>
             <td>
-              <span class="session-time" data-time="{{ entry.start_time or '' }}">{{ entry.start_time or 'Unknown' }}</span>
+              <span class="session-time" data-time="{{ entry.start_time or '' }}">{{ entry.start_time | friendly_datetime('Unknown') }}</span>
             </td>
             <td>{{ entry.conflict_details or 'Conflict detected' }}</td>
           </tr>

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -346,7 +346,7 @@ function appendLogRow(entry) {
   const tr = document.createElement('tr');
   const reqLabel = entry.message && entry.message !== 'submitted' ? entry.message : '—';
   const sess = sessionMap[entry.session_ref] || {};
-  const sessionTimeStr = sess.start_time_iso ? formatLocalTime(sess.start_time_iso) : '—';
+  const sessionTimeStr = sess.start_time_iso ? formatDisplayTime(sess.start_time_iso) : '—';
   tr.innerHTML =
     '<td><span class="req-badge">' + reqLabel + '</span></td>' +
     '<td>' + (sess.title || '—') + '</td>' +
@@ -381,30 +381,33 @@ function refreshProgress() {
     .catch(console.error);
 }
 
-function formatLocalTime(isoString) {
+// One zone for everyone, marked with its abbreviation, rather than whatever the
+// browser is set to — two people comparing screens should read the same times.
+const DISPLAY_TIMEZONE = '{{ display_timezone }}';
+
+function formatDisplayTime(isoString) {
   if (!isoString) return '';
   try {
     const d = new Date(isoString);
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const formatted = new Intl.DateTimeFormat('en-CA', {
       weekday: 'short', month: 'short', day: 'numeric',
       hour: 'numeric', minute: '2-digit',
-      timeZone: tz, timeZoneName: 'short'
+      timeZone: DISPLAY_TIMEZONE, timeZoneName: 'short'
     }).format(d);
     return formatted;
   } catch(e) { return isoString; }
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  // Format all card times in browser local timezone
+  // Format all card times in the app's display timezone
   document.querySelectorAll('.card-time[data-iso]').forEach(function(el) {
     const iso = el.dataset.iso;
-    if (iso) el.textContent = formatLocalTime(iso);
+    if (iso) el.textContent = formatDisplayTime(iso);
   });
   // Format session date/time and submitted date/time columns in the log table
   document.querySelectorAll('.log-session-time[data-iso], .log-submitted-time[data-iso]').forEach(function(el) {
     const iso = el.dataset.iso;
-    if (iso) el.textContent = formatLocalTime(iso);
+    if (iso) el.textContent = formatDisplayTime(iso);
   });
 
   startStream();

--- a/tests/test_daily_summary.py
+++ b/tests/test_daily_summary.py
@@ -188,3 +188,39 @@ def test_a_failed_send_is_retried_on_the_next_run(monkeypatch, registered_user):
 
     assert tasks.send_daily_summaries() == 1
     assert delivered == [USER_EMAIL]
+
+
+def test_the_summary_reads_in_edmonton_time_and_marks_the_zone(monkeypatch):
+    """The people reading it are in Edmonton, so the times must not need converting."""
+    import emailer
+
+    body = {}
+    monkeypatch.setattr(emailer, "_send",
+                        lambda to, subject, text: body.update({"to": to, "text": text}))
+
+    emailer.send_daily_summary_email(
+        USER_EMAIL,
+        booked_sessions=[{"title": "Session", "school": "Nakasuk School",
+                          "ticket_id": "REQ001", "start_time": "2026-08-19T20:36:00+00:00"}],
+        conflict_sessions=[],
+        summary_date="2026-08-19")
+
+    assert "All times below are Edmonton time." in body["text"]
+    # 20:36 UTC is 2:36 pm in Edmonton — and 4:36 pm Eastern, where this used to land.
+    assert "Wed, Aug 19 at 2:36 pm MDT" in body["text"]
+
+
+def test_every_email_marks_its_timezone(monkeypatch):
+    """A bare '2:36 pm' is a guess for anyone who is not sure where the app thinks it is."""
+    import emailer
+
+    sent = []
+    monkeypatch.setattr(emailer, "_send", lambda to, subject, text: sent.append(text))
+    session = {"title": "Session", "school": "Nakasuk School", "ticket_id": "REQ001",
+               "start_time": "2026-01-19T20:36:00+00:00"}
+
+    emailer.send_conflict_email(USER_EMAIL, [session])
+    emailer.send_booking_summary_email(USER_EMAIL, [session], [], manual=True)
+
+    # January, so Mountain is on standard time.
+    assert all("Mon, Jan 19 at 1:36 pm MST" in text for text in sent)


### PR DESCRIPTION
Times were rendered in `America/Toronto` on the server and in whatever zone the viewer's machine was set to in the browser, with nothing on screen saying which. Two people comparing screens could read the same session as two different times.

Everything a person reads now uses one zone and prints its abbreviation — `Wed, Aug 19 at 2:36 pm MDT`:

- **Emails** (conflict, booking run, daily summary) via `friendly_datetime`, which now appends the zone abbreviation. The daily summary also states `All times below are Edmonton time.`
- **Dashboard and progress page** — the browser-side `Intl.DateTimeFormat` calls were using the viewer's machine zone; they now pin the app's display zone, passed to the templates as a `display_timezone` Jinja global. Server-rendered fallbacks (including the "Started 14:36 UTC" notice and the raw ISO strings in the booked/conflict tables) moved to the same filter.

The zone is its own `DISPLAY_TZ` setting rather than `AUTO_SCAN_TZ`, which prod sets to `America/Toronto`: that one says when the scheduled scan fires, a different question from how a time is shown. `render.yaml` declares `DISPLAY_TZ: America/Edmonton`.

Left alone deliberately:

- `gn_ticket.py` still types Eastern into the GN form — that is data filed with the government, not something anyone here reads.
- `DAILY_SUMMARY_TZ` still decides *when* the summary sends (5pm Eastern), which is a send trigger rather than a display.

Tests: two new cases in `tests/test_daily_summary.py` pin 20:36 UTC to `2:36 pm MDT` in the summary and assert the conflict and booking emails carry `MST` in January. Full suite: 178 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
