### PR TITLE
Count every scan interval out from 9am Eastern

### DIFF
--- a/models.py
+++ b/models.py
@@ -44,7 +44,8 @@ class UserPreference(Base):
     buffer_after = Column(Integer, default=10)
     auto_booking_enabled = Column(Boolean, default=False)
     # How often the scheduled scan should run for this user. The cron job fires
-    # hourly and skips whoever is not due yet, so this is per-person.
+    # hourly and skips whoever is not due yet, so this is per-person. The interval
+    # is counted out from a fixed hour, so every offered value divides 24.
     scan_frequency_hours = Column(Integer, default=24)
     window_past_days = Column(Integer, default=14)
     window_future_days = Column(Integer, default=90)

--- a/render.yaml
+++ b/render.yaml
@@ -41,8 +41,15 @@ envVarGroups:
         sync: false
       - key: GN_INLINE_TASKS
         value: "1"
+      # The zone the schedule is read in — not the zone times are displayed in,
+      # which is DISPLAY_TZ below.
       - key: AUTO_SCAN_TZ
-        value: America/Toronto
+        value: America/New_York
+      # Which hour a once-a-day scan lands on, in AUTO_SCAN_TZ. Shorter intervals
+      # fall where they fall; a daily one would otherwise sit at whatever hour the
+      # user's first scan happened to run, 3am included.
+      - key: DAILY_SCAN_HOUR
+        value: "9"
       # The zone every time is shown in, on the pages and in the emails, marked with
       # its abbreviation so it is never ambiguous. Separate from AUTO_SCAN_TZ, which
       # only says when the scheduled scan fires.
@@ -112,6 +119,8 @@ services:
     # Fires hourly and scans only the users whose chosen interval has elapsed, so
     # per-person frequency (1/5/12/24h) is a dashboard setting rather than a schedule
     # change. A run with nobody due exits in seconds, and cron jobs bill per minute.
+    # The hourly tick is what an "every hour" user needs; a daily user answers "due"
+    # on one tick of the 24, the one at DAILY_SCAN_HOUR in AUTO_SCAN_TZ.
     schedule: "0 * * * *"
     dockerCommand: python run_scan.py
     envVars:

--- a/render.yaml
+++ b/render.yaml
@@ -45,10 +45,11 @@ envVarGroups:
       # which is DISPLAY_TZ below.
       - key: AUTO_SCAN_TZ
         value: America/New_York
-      # Which hour a once-a-day scan lands on, in AUTO_SCAN_TZ. Shorter intervals
-      # fall where they fall; a daily one would otherwise sit at whatever hour the
-      # user's first scan happened to run, 3am included.
-      - key: DAILY_SCAN_HOUR
+      # The hour every scan interval is counted out from, in AUTO_SCAN_TZ. Daily
+      # users land on it, twice-daily users on it and twelve hours later, and so
+      # on. Without an anchor the hour would be whenever a user's first scan
+      # happened to run, 3am included, and an on-demand scan would move it again.
+      - key: SCAN_ANCHOR_HOUR
         value: "9"
       # The zone every time is shown in, on the pages and in the emails, marked with
       # its abbreviation so it is never ambiguous. Separate from AUTO_SCAN_TZ, which
@@ -116,11 +117,11 @@ services:
     # instance costs cents per month at one short run per day.
     plan: standard
     dockerfilePath: ./Dockerfile
-    # Fires hourly and scans only the users whose chosen interval has elapsed, so
-    # per-person frequency (1/5/12/24h) is a dashboard setting rather than a schedule
-    # change. A run with nobody due exits in seconds, and cron jobs bill per minute.
-    # The hourly tick is what an "every hour" user needs; a daily user answers "due"
-    # on one tick of the 24, the one at DAILY_SCAN_HOUR in AUTO_SCAN_TZ.
+    # Fires hourly and scans only the users whose slot has come round, so per-person
+    # frequency (1/4/12/24h) is a dashboard setting rather than a schedule change.
+    # A run with nobody due exits in seconds, and cron jobs bill per minute.
+    # The hourly tick is what an "every hour" user needs; every other interval is
+    # counted out from SCAN_ANCHOR_HOUR and answers "due" on its own share of them.
     schedule: "0 * * * *"
     dockerCommand: python run_scan.py
     envVars:

--- a/tasks.py
+++ b/tasks.py
@@ -71,14 +71,11 @@ BUSY_NOTICE_SECONDS = int(os.getenv("GN_BUSY_NOTICE_SECONDS", "300"))
 # times are shown in: this one says when things fire.
 SCAN_TZ = os.getenv("AUTO_SCAN_TZ", "America/New_York")
 
-# Which hour a once-a-day scan lands on, in SCAN_TZ. An interval shorter than a
-# day has to fall where it falls, but a daily user has 24 hours to choose from
-# and no reason to be scanned at 3am because that is when they first signed up.
-DAILY_SCAN_HOUR = int(os.getenv("DAILY_SCAN_HOUR", "9"))
-
-# A missed daily run — a failed job, a deploy, an outage — should cost hours, not
-# a whole day. Past this, the next hourly tick catches the user up.
-MISSED_DAILY_SCAN_GRACE = timedelta(hours=25)
+# Every interval is measured out from this hour, in SCAN_TZ. Left to elapsed time
+# alone the hour would be whenever the user's first scan happened to land — 3am
+# for anyone unlucky — and an on-demand scan would move it again. Anchoring means
+# a daily user is scanned at 9am, a twice-daily one at 9am and 9pm, and so on.
+SCAN_ANCHOR_HOUR = int(os.getenv("SCAN_ANCHOR_HOUR", "9"))
 
 celery_app = Celery("gn_ticket", broker=REDIS_URL, backend=REDIS_URL)
 celery_app.conf.timezone = SCAN_TZ
@@ -95,22 +92,35 @@ celery_app.conf.beat_schedule = {
 logger = logging.getLogger(__name__)
 
 
-def daily_scan_time_label():
-    """The hour a daily scan lands on, marked with its zone: '9am EDT'."""
-    suffix = "am" if DAILY_SCAN_HOUR < 12 else "pm"
-    clock = DAILY_SCAN_HOUR % 12 or 12
-    abbreviation = datetime.now(_scan_zone()).strftime("%Z")
-    return f"{clock}{suffix} {abbreviation}".strip()
+def scan_hours(frequency_hours):
+    """The local hours a user on this interval is scanned at.
+
+    Counted out from SCAN_ANCHOR_HOUR, which is why every offered interval divides
+    24: 4 hours gives six evenly spaced slots a day, 5 would give five and a gap.
+    """
+    step = max(1, frequency_hours)
+    return tuple(sorted((SCAN_ANCHOR_HOUR + n * step) % 24
+                        for n in range(max(1, 24 // step))))
+
+
+def _clock(hour):
+    """An hour as a person writes it: 9 -> '9am', 21 -> '9pm'."""
+    return f"{hour % 12 or 12}{'am' if hour < 12 else 'pm'}"
 
 
 def auto_scan_time_label(frequency_hours=None):
-    """Human-readable description of how often the scheduled scan runs."""
+    """Human-readable description of when the scheduled scan runs."""
     hours = frequency_hours or DEFAULT_SCAN_FREQUENCY_HOURS
     if hours == 1:
         return "every hour"
-    if hours == 24:
-        return f"once a day, at {daily_scan_time_label()}"
-    return f"every {hours} hours"
+
+    zone = datetime.now(_scan_zone()).strftime("%Z")
+    slots = scan_hours(hours)
+    if len(slots) == 1:
+        return f"once a day, at {_clock(slots[0])} {zone}".strip()
+    if len(slots) == 2:
+        return f"at {_clock(slots[0])} and {_clock(slots[1])} {zone}".strip()
+    return f"every {hours} hours, from {_clock(SCAN_ANCHOR_HOUR)} {zone}".strip()
 
 
 def _try_acquire_lock(name, token, ttl):
@@ -546,10 +556,9 @@ def user_is_due(user_email, now=None):
     interval is simply skipped 23 times out of 24 — unless they have asked for a
     scan explicitly, which overrides the interval.
 
-    Which 23 it skips matters, though. A daily interval leaves 24 hours to choose
-    from, and elapsed time alone would hand that choice to whenever the user last
-    happened to be scanned — 3am for anyone whose first scan landed there. Daily
-    users are pinned to DAILY_SCAN_HOUR instead; see _daily_scan_is_due.
+    Which 23 it skips matters, though, and elapsed time alone would hand that
+    choice to whenever the user last happened to be scanned. The interval is
+    measured out from SCAN_ANCHOR_HOUR instead; see _scheduled_scan_is_due.
     """
     if has_pending_request(user_email):
         return True
@@ -565,12 +574,7 @@ def user_is_due(user_email, now=None):
     if previous.tzinfo is not None:
         previous = previous.replace(tzinfo=None)
 
-    if hours >= 24:
-        return _daily_scan_is_due(previous, now)
-
-    # A little grace, or an hourly job whose runs drift by seconds would push a
-    # 1 hour interval out to 2 hours.
-    return previous + timedelta(hours=hours) - timedelta(minutes=5) <= now
+    return _scheduled_scan_is_due(previous, now, hours)
 
 
 def _scan_zone():
@@ -581,28 +585,29 @@ def _scan_zone():
         return timezone.utc
 
 
-def _daily_scan_is_due(previous, now):
-    """Whether a once-a-day user is due, given naive-UTC `previous` and `now`.
+def _scheduled_scan_is_due(previous, now, hours):
+    """Whether this interval's slot has come round, given naive-UTC times.
 
-    "Has a day elapsed" is the wrong question for a daily user: someone who
-    pressed "Run scan now" at 4pm would have their next scan fall due at 4pm the
-    following day, and stay there — which is the drift this exists to remove. The
-    question is whether today's scheduled scan has happened yet.
+    "Has the interval elapsed" is the wrong question: someone who pressed "Run
+    scan now" at 4pm would have their next daily scan fall due at 4pm the day
+    after, and stay there — which is the drift this exists to remove. The question
+    is whether the slot this hour belongs to has been scanned yet.
 
-    The hourly cron and the local hour do the rest of the work between them: this
-    is true on exactly one tick a day, and it is true on the same wall-clock tick
-    on both sides of a daylight saving change.
+    Reading the local hour on each tick is also what carries this through a
+    daylight saving change: the hourly cron has a tick at 9am either way, so there
+    is no offset to keep in step.
     """
     local_now = now.replace(tzinfo=timezone.utc).astimezone(_scan_zone())
 
-    if local_now.hour == DAILY_SCAN_HOUR:
-        todays_run = local_now.replace(minute=0, second=0, microsecond=0)
-        if previous < todays_run.astimezone(timezone.utc).replace(tzinfo=None):
+    if local_now.hour in scan_hours(hours):
+        slot = local_now.replace(minute=0, second=0, microsecond=0)
+        if previous < slot.astimezone(timezone.utc).replace(tzinfo=None):
             return True
 
-    # Missing the scheduled hour should not cost a whole day. Catching up here
-    # does not move tomorrow's run: that one is anchored to the clock, not to this.
-    return previous + MISSED_DAILY_SCAN_GRACE <= now
+    # A missed slot — a failed run, a deploy, an outage — should cost an hour or
+    # two rather than a whole interval. Catching up here does not move the next
+    # slot: those are anchored to the clock, not to the last scan.
+    return previous + timedelta(hours=hours + 1) <= now
 
 
 @celery_app.task(name="tasks.run_scheduled_scan")

--- a/tasks.py
+++ b/tasks.py
@@ -67,8 +67,21 @@ BUSY_MAX_WAIT_SECONDS = int(os.getenv("GN_BUSY_MAX_WAIT_SECONDS", str(60 * 60)))
 # How often to announce that we are still waiting, so logs don't fill with notices.
 BUSY_NOTICE_SECONDS = int(os.getenv("GN_BUSY_NOTICE_SECONDS", "300"))
 
+# The zone the schedule is read in. Separate from DISPLAY_TZ, which is the zone
+# times are shown in: this one says when things fire.
+SCAN_TZ = os.getenv("AUTO_SCAN_TZ", "America/New_York")
+
+# Which hour a once-a-day scan lands on, in SCAN_TZ. An interval shorter than a
+# day has to fall where it falls, but a daily user has 24 hours to choose from
+# and no reason to be scanned at 3am because that is when they first signed up.
+DAILY_SCAN_HOUR = int(os.getenv("DAILY_SCAN_HOUR", "9"))
+
+# A missed daily run — a failed job, a deploy, an outage — should cost hours, not
+# a whole day. Past this, the next hourly tick catches the user up.
+MISSED_DAILY_SCAN_GRACE = timedelta(hours=25)
+
 celery_app = Celery("gn_ticket", broker=REDIS_URL, backend=REDIS_URL)
-celery_app.conf.timezone = os.getenv("AUTO_SCAN_TZ", "America/Toronto")
+celery_app.conf.timezone = SCAN_TZ
 celery_app.conf.beat_schedule = {
     "daily_auto_scan": {
         "task": "tasks.run_scheduled_scan",
@@ -82,13 +95,21 @@ celery_app.conf.beat_schedule = {
 logger = logging.getLogger(__name__)
 
 
+def daily_scan_time_label():
+    """The hour a daily scan lands on, marked with its zone: '9am EDT'."""
+    suffix = "am" if DAILY_SCAN_HOUR < 12 else "pm"
+    clock = DAILY_SCAN_HOUR % 12 or 12
+    abbreviation = datetime.now(_scan_zone()).strftime("%Z")
+    return f"{clock}{suffix} {abbreviation}".strip()
+
+
 def auto_scan_time_label(frequency_hours=None):
     """Human-readable description of how often the scheduled scan runs."""
     hours = frequency_hours or DEFAULT_SCAN_FREQUENCY_HOURS
     if hours == 1:
         return "every hour"
     if hours == 24:
-        return "once a day"
+        return f"once a day, at {daily_scan_time_label()}"
     return f"every {hours} hours"
 
 
@@ -524,6 +545,11 @@ def user_is_due(user_email, now=None):
     The cron job fires hourly and asks this of everyone, so a user on a 24 hour
     interval is simply skipped 23 times out of 24 — unless they have asked for a
     scan explicitly, which overrides the interval.
+
+    Which 23 it skips matters, though. A daily interval leaves 24 hours to choose
+    from, and elapsed time alone would hand that choice to whenever the user last
+    happened to be scanned — 3am for anyone whose first scan landed there. Daily
+    users are pinned to DAILY_SCAN_HOUR instead; see _daily_scan_is_due.
     """
     if has_pending_request(user_email):
         return True
@@ -539,9 +565,44 @@ def user_is_due(user_email, now=None):
     if previous.tzinfo is not None:
         previous = previous.replace(tzinfo=None)
 
+    if hours >= 24:
+        return _daily_scan_is_due(previous, now)
+
     # A little grace, or an hourly job whose runs drift by seconds would push a
     # 1 hour interval out to 2 hours.
     return previous + timedelta(hours=hours) - timedelta(minutes=5) <= now
+
+
+def _scan_zone():
+    try:
+        return ZoneInfo(SCAN_TZ)
+    except Exception:
+        logger.warning("Unknown AUTO_SCAN_TZ %r; reading the schedule in UTC.", SCAN_TZ)
+        return timezone.utc
+
+
+def _daily_scan_is_due(previous, now):
+    """Whether a once-a-day user is due, given naive-UTC `previous` and `now`.
+
+    "Has a day elapsed" is the wrong question for a daily user: someone who
+    pressed "Run scan now" at 4pm would have their next scan fall due at 4pm the
+    following day, and stay there — which is the drift this exists to remove. The
+    question is whether today's scheduled scan has happened yet.
+
+    The hourly cron and the local hour do the rest of the work between them: this
+    is true on exactly one tick a day, and it is true on the same wall-clock tick
+    on both sides of a daylight saving change.
+    """
+    local_now = now.replace(tzinfo=timezone.utc).astimezone(_scan_zone())
+
+    if local_now.hour == DAILY_SCAN_HOUR:
+        todays_run = local_now.replace(minute=0, second=0, microsecond=0)
+        if previous < todays_run.astimezone(timezone.utc).replace(tzinfo=None):
+            return True
+
+    # Missing the scheduled hour should not cost a whole day. Catching up here
+    # does not move tomorrow's run: that one is anchored to the clock, not to this.
+    return previous + MISSED_DAILY_SCAN_GRACE <= now
 
 
 @celery_app.task(name="tasks.run_scheduled_scan")

--- a/tests/test_scan_frequency.py
+++ b/tests/test_scan_frequency.py
@@ -2,8 +2,9 @@
 
 The cron job fires hourly and asks each opted-in user whether their chosen
 interval has elapsed, so 1/5/12/24 hours is a dashboard setting rather than a
-schedule change. The daily interval also says which of the 24 hours it uses:
-9am Eastern, rather than wherever the last scan happened to leave it.
+schedule change. Every interval is counted out from 9am Eastern rather than from
+whenever the last scan happened to land, so the hours it uses are the same for
+everyone on it.
 """
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -11,7 +12,8 @@ from zoneinfo import ZoneInfo
 import pytest
 
 import tasks
-from user_profiles import (DEFAULT_SCAN_FREQUENCY_HOURS, SCAN_FREQUENCY_CHOICES,
+from user_profiles import (DEFAULT_SCAN_FREQUENCY_HOURS, RETIRED_SCAN_FREQUENCIES,
+                           SCAN_FREQUENCY_CHOICES, _retire_removed_scan_frequencies,
                            normalize_scan_frequency, user_manager)
 
 from test_tasks import USER_EMAIL, registered_user  # noqa: F401
@@ -44,13 +46,22 @@ def eastern(local):
 
 
 def test_the_offered_intervals():
-    assert SCAN_FREQUENCY_CHOICES == (1, 5, 12, 24)
+    assert SCAN_FREQUENCY_CHOICES == (1, 4, 12, 24)
     assert DEFAULT_SCAN_FREQUENCY_HOURS == 24
 
 
+def test_every_offered_interval_divides_the_day():
+    """Anchoring only spaces slots evenly if the interval fits a day a whole number
+    of times. 5 hours did not, which is why it was retired."""
+    for hours in SCAN_FREQUENCY_CHOICES:
+        assert 24 % hours == 0
+        assert len(tasks.scan_hours(hours)) == 24 // hours
+
+
 @pytest.mark.parametrize("value,expected", [
-    (1, 1), ("5", 5), (12, 12), ("24", 24),
+    (1, 1), ("4", 4), (12, 12), ("24", 24),
     (3, 24), ("banana", 24), (None, 24), (0, 24), (-1, 24),
+    (5, 24),  # retired: no longer an answer a form post can give.
 ])
 def test_only_offered_intervals_are_accepted(value, expected):
     """A hand-edited form post must not produce a two-minute scan loop."""
@@ -69,10 +80,10 @@ def test_a_user_scanned_just_now_is_not_due(registered_user):
 
 
 def test_a_user_becomes_due_once_the_interval_elapses(registered_user):
-    set_frequency(USER_EMAIL, 5)
-    record_scan_at(USER_EMAIL, datetime.utcnow() - timedelta(hours=5, minutes=1))
+    set_frequency(USER_EMAIL, 4)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 09:00"))
 
-    assert tasks.user_is_due(USER_EMAIL) is True
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 13:00")) is True
 
 
 def test_a_shorter_interval_comes_due_sooner(registered_user):
@@ -91,9 +102,9 @@ def test_a_shorter_interval_comes_due_sooner(registered_user):
 def test_an_hourly_user_is_not_pushed_to_two_hours_by_drift(registered_user):
     """Cron fires on the hour; a scan that began seconds late must still count."""
     set_frequency(USER_EMAIL, 1)
-    record_scan_at(USER_EMAIL, datetime.utcnow() - timedelta(minutes=58))
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 09:00") + timedelta(seconds=40))
 
-    assert tasks.user_is_due(USER_EMAIL) is True
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 10:00")) is True
 
 
 def test_the_scheduled_run_scans_only_who_is_due(monkeypatch, registered_user):
@@ -129,13 +140,14 @@ def test_the_frequency_survives_a_round_trip(registered_user):
 
 def test_the_label_reads_naturally():
     assert tasks.auto_scan_time_label(1) == "every hour"
-    assert tasks.auto_scan_time_label(5) == "every 5 hours"
+    assert tasks.auto_scan_time_label(4).startswith("every 4 hours, from 9am")
+    assert tasks.auto_scan_time_label(12).startswith("at 9am and 9pm")
     assert tasks.auto_scan_time_label(24).startswith("once a day, at 9am")
 
 
-# The daily interval and the hour it lands on. The cron job still fires hourly —
-# a user set to "every hour" needs it to — so what pins the once-a-day scan to
-# the morning is which of those 24 ticks a daily user answers "due" on.
+# The hours each interval lands on. The cron job still fires hourly — a user set
+# to "every hour" needs it to — so what pins a scan to the morning is which of
+# those 24 ticks the user's interval answers "due" on.
 
 def test_a_daily_user_is_due_at_nine_eastern(registered_user):
     set_frequency(USER_EMAIL, 24)
@@ -193,12 +205,35 @@ def test_a_catch_up_does_not_move_the_next_morning(registered_user):
     assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-16 09:00")) is True
 
 
-def test_shorter_intervals_still_run_at_any_hour(registered_user):
-    """Only the daily interval gets an opinion about the hour."""
-    set_frequency(USER_EMAIL, 5)
+def test_a_four_hour_interval_fills_the_day_from_nine(registered_user):
+    """Six evenly spaced slots, counted out from the anchor and wrapping midnight."""
+    assert tasks.scan_hours(4) == (1, 5, 9, 13, 17, 21)
+
+    set_frequency(USER_EMAIL, 4)
     record_scan_at(USER_EMAIL, eastern("2026-07-15 21:00"))
 
-    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-16 02:00")) is True
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 23:00")) is False
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-16 01:00")) is True
+
+
+def test_a_twice_daily_user_gets_nine_and_nine(registered_user):
+    assert tasks.scan_hours(12) == (9, 21)
+
+    set_frequency(USER_EMAIL, 12)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 09:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 15:00")) is False
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 21:00")) is True
+
+
+def test_an_hourly_user_still_answers_to_every_tick(registered_user):
+    """Anchoring must not thin out the interval that wants all 24 hours."""
+    assert len(tasks.scan_hours(1)) == 24
+
+    set_frequency(USER_EMAIL, 1)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 03:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 04:00")) is True
 
 
 def test_asking_for_a_scan_still_beats_the_hour(registered_user):
@@ -208,3 +243,39 @@ def test_asking_for_a_scan_still_beats_the_hour(registered_user):
     tasks.request_scan(USER_EMAIL)
 
     assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 16:00")) is True
+
+
+def store_frequency_directly(email, hours):
+    """Write a raw value, bypassing the normalising the dashboard does on save."""
+    from sqlalchemy import select
+
+    from db import SessionLocal
+    from models import User, UserPreference
+
+    with SessionLocal() as db:
+        user = db.execute(select(User).where(User.email == email)).scalar_one()
+        prefs = db.execute(
+            select(UserPreference).where(UserPreference.user_id == user.id)
+        ).scalar_one()
+        prefs.scan_frequency_hours = hours
+        db.commit()
+
+
+def test_a_retired_interval_is_moved_to_what_replaced_it(registered_user):
+    """Left alone, a stored 5 would select nothing in the dashboard's dropdown,
+    and the next save would silently pick the first option for the user."""
+    assert RETIRED_SCAN_FREQUENCIES == {5: 4}
+    store_frequency_directly(USER_EMAIL, 5)
+
+    _retire_removed_scan_frequencies()
+
+    assert user_manager.get_preferences(USER_EMAIL)["scan_frequency_hours"] == 4
+
+
+def test_moving_retired_intervals_leaves_the_offered_ones_alone(registered_user):
+    for hours in SCAN_FREQUENCY_CHOICES:
+        store_frequency_directly(USER_EMAIL, hours)
+
+        _retire_removed_scan_frequencies()
+
+        assert user_manager.get_preferences(USER_EMAIL)["scan_frequency_hours"] == hours

--- a/tests/test_scan_frequency.py
+++ b/tests/test_scan_frequency.py
@@ -2,9 +2,11 @@
 
 The cron job fires hourly and asks each opted-in user whether their chosen
 interval has elapsed, so 1/5/12/24 hours is a dashboard setting rather than a
-schedule change.
+schedule change. The daily interval also says which of the 24 hours it uses:
+9am Eastern, rather than wherever the last scan happened to leave it.
 """
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -30,6 +32,15 @@ def record_scan_at(email, when):
         user = db.execute(select(User).where(User.email == email)).scalar_one()
         db.add(ScanResult(user_id=user.id, scanned_at=when, summary="{}"))
         db.commit()
+
+
+EASTERN = ZoneInfo("America/New_York")
+
+
+def eastern(local):
+    """A wall-clock time in Eastern, as the naive UTC the scan code works in."""
+    moment = datetime.strptime(local, "%Y-%m-%d %H:%M").replace(tzinfo=EASTERN)
+    return moment.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def test_the_offered_intervals():
@@ -66,13 +77,15 @@ def test_a_user_becomes_due_once_the_interval_elapses(registered_user):
 
 def test_a_shorter_interval_comes_due_sooner(registered_user):
     """The same elapsed time reads differently at 1 hour and at 24."""
-    record_scan_at(USER_EMAIL, datetime.utcnow() - timedelta(hours=2))
+    # Pinned off the daily hour: at 9am a daily user is due whatever the elapsed time.
+    now = eastern("2026-07-15 14:00")
+    record_scan_at(USER_EMAIL, now - timedelta(hours=2))
 
     set_frequency(USER_EMAIL, 1)
-    assert tasks.user_is_due(USER_EMAIL) is True
+    assert tasks.user_is_due(USER_EMAIL, now=now) is True
 
     set_frequency(USER_EMAIL, 24)
-    assert tasks.user_is_due(USER_EMAIL) is False
+    assert tasks.user_is_due(USER_EMAIL, now=now) is False
 
 
 def test_an_hourly_user_is_not_pushed_to_two_hours_by_drift(registered_user):
@@ -117,4 +130,81 @@ def test_the_frequency_survives_a_round_trip(registered_user):
 def test_the_label_reads_naturally():
     assert tasks.auto_scan_time_label(1) == "every hour"
     assert tasks.auto_scan_time_label(5) == "every 5 hours"
-    assert tasks.auto_scan_time_label(24) == "once a day"
+    assert tasks.auto_scan_time_label(24).startswith("once a day, at 9am")
+
+
+# The daily interval and the hour it lands on. The cron job still fires hourly —
+# a user set to "every hour" needs it to — so what pins the once-a-day scan to
+# the morning is which of those 24 ticks a daily user answers "due" on.
+
+def test_a_daily_user_is_due_at_nine_eastern(registered_user):
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-14 09:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 09:00")) is True
+
+
+def test_a_daily_user_is_not_due_in_the_middle_of_the_night(registered_user):
+    """The whole point: 3am is a tick like any other, and daily users skip it."""
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-14 09:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 03:00")) is False
+
+
+def test_a_daily_user_is_not_due_again_later_the_same_day(registered_user):
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 09:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 10:00")) is False
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 23:00")) is False
+
+
+def test_an_afternoon_scan_does_not_drag_tomorrow_into_the_afternoon(registered_user):
+    """Pressing "Run scan now" at 4pm must not move the daily scan to 4pm."""
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-14 16:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 09:00")) is True
+
+
+def test_nine_eastern_survives_daylight_saving(registered_user):
+    """Same wall-clock hour in winter, an hour later in UTC. Both are 9am to a user."""
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-01-14 09:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-01-15 08:00")) is False
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-01-15 09:00")) is True
+
+
+def test_a_missed_morning_is_caught_up_rather_than_skipped_for_a_day(registered_user):
+    """A failed 9am run should cost hours, not until tomorrow morning."""
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-14 09:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 10:00")) is True
+
+
+def test_a_catch_up_does_not_move_the_next_morning(registered_user):
+    """Tomorrow is anchored to the clock, not to whenever the catch-up ran."""
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 11:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-16 09:00")) is True
+
+
+def test_shorter_intervals_still_run_at_any_hour(registered_user):
+    """Only the daily interval gets an opinion about the hour."""
+    set_frequency(USER_EMAIL, 5)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 21:00"))
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-16 02:00")) is True
+
+
+def test_asking_for_a_scan_still_beats_the_hour(registered_user):
+    """An explicit request is not made to wait until the morning."""
+    set_frequency(USER_EMAIL, 24)
+    record_scan_at(USER_EMAIL, eastern("2026-07-15 09:00"))
+    tasks.request_scan(USER_EMAIL)
+
+    assert tasks.user_is_due(USER_EMAIL, now=eastern("2026-07-15 16:00")) is True

--- a/user_profiles.py
+++ b/user_profiles.py
@@ -15,7 +15,9 @@ ensure_column("user_preferences", "scan_frequency_hours", "INTEGER", "24")
 
 
 # How often a user's scheduled scan runs. The cron job fires hourly and skips
-# anyone not yet due, so anything coarser than hourly is a per-user choice.
+# anyone not yet due, so anything coarser than hourly is a per-user choice. The
+# 24 hour choice also picks its hour — see DAILY_SCAN_HOUR in tasks.py — rather
+# than drifting to wherever the user's last scan left it.
 SCAN_FREQUENCY_CHOICES = (1, 5, 12, 24)
 DEFAULT_SCAN_FREQUENCY_HOURS = 24
 

--- a/user_profiles.py
+++ b/user_profiles.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Optional
 from cryptography.fernet import Fernet
 from sqlalchemy import select
+from sqlalchemy import update as sa_update
 
 from db import SessionLocal, Base, engine, ensure_column
 from models import User, UserCredential, UserPreference
@@ -15,11 +16,36 @@ ensure_column("user_preferences", "scan_frequency_hours", "INTEGER", "24")
 
 
 # How often a user's scheduled scan runs. The cron job fires hourly and skips
-# anyone not yet due, so anything coarser than hourly is a per-user choice. The
-# 24 hour choice also picks its hour — see DAILY_SCAN_HOUR in tasks.py — rather
-# than drifting to wherever the user's last scan left it.
-SCAN_FREQUENCY_CHOICES = (1, 5, 12, 24)
+# anyone not yet due, so anything coarser than hourly is a per-user choice.
+#
+# Every choice divides 24, because the interval is counted out from a fixed hour
+# rather than from the last scan — see SCAN_ANCHOR_HOUR in tasks.py. 4 hours gives
+# six evenly spaced slots a day; 5, which this offered until the schedule was
+# anchored, gave four and then a nine hour gap over the anchor.
+SCAN_FREQUENCY_CHOICES = (1, 4, 12, 24)
 DEFAULT_SCAN_FREQUENCY_HOURS = 24
+
+# Intervals that used to be offered, and what replaced them. Anyone still stored
+# on one is moved on import: leaving them there would render the dashboard's
+# dropdown with nothing selected, and the next save would silently pick for them.
+RETIRED_SCAN_FREQUENCIES = {5: 4}
+
+
+def _retire_removed_scan_frequencies():
+    """Move stored intervals that are no longer offered. A no-op once none are."""
+    from models import UserPreference
+
+    with SessionLocal() as db:
+        for retired, replacement in RETIRED_SCAN_FREQUENCIES.items():
+            db.execute(
+                sa_update(UserPreference)
+                .where(UserPreference.scan_frequency_hours == retired)
+                .values(scan_frequency_hours=replacement)
+            )
+        db.commit()
+
+
+_retire_removed_scan_frequencies()
 
 
 def normalize_scan_frequency(value):


### PR DESCRIPTION
The cron job kept firing hourly — a user set to "every hour" needs it to, and the per-person interval is what decides who gets scanned on any given tick. What was missing is *which* of the 24 ticks a user answers "due" on.

Elapsed time alone gave that choice to whenever the user last happened to be scanned. Whoever's first scan landed at 3am was scanned at 3am every day after, and pressing "Run scan now" at 4pm moved them there permanently. Every interval is now measured out from a fixed anchor hour instead.

## The hours each interval lands on

| Interval | Hours | Dashboard reads |
|---|---|---|
| 1h | all 24 | "every hour" |
| 4h | 1, 5, 9, 13, 17, 21 | "every 4 hours, from 9am EDT" |
| 12h | 9, 21 | "at 9am and 9pm EDT" |
| 24h | 9 | "once a day, at 9am EDT" |

`user_is_due()` has a single path now: due if the current local hour is one of your slots and that slot has not been scanned yet. Reading the local hour on each tick is also what carries this through a daylight saving change — the hourly cron has a tick at 9am either way, so there is no UTC offset to keep in step.

## 5 hours becomes 4

Anchoring only spaces slots evenly if the interval fits a whole number of times into a day. From 9am, a 5 hour interval gives 9, 14, 19 and then a nine hour gap back round. 4 hours gives six evenly spaced slots.

Anyone stored on the retired 5 is moved to 4 on import. Leaving them would have been worse than untidy: the dashboard's dropdown would render with no option selected, and their next save would silently pick the first one for them.

## Drift grace out, missed-slot catch-up in

The five minute grace existed because a scan starting seconds late would push a 1 hour user's next window past the following tick. A slot is a whole clock hour, so a run starting at 9:00:40 is still in the 9am slot and the grace is no longer needed.

Replacing it: an hour past the interval, the next tick picks up a user whose slot was missed, so a failed 9am run costs a daily user an hour rather than a day. Catching up at 10am does not move tomorrow's 9am — slots are anchored to the clock, not to the last scan.

## Config

- `AUTO_SCAN_TZ` moves from `America/Toronto` to `America/New_York` — the same offsets, named for the zone the hour is quoted in.
- `SCAN_ANCHOR_HOUR` is new, default `9`, declared in the blueprint so the hour is tunable without a deploy.

## Testing

193 tests pass. New coverage for the slot rule at each interval, the midnight wrap on the 4 hour interval, both sides of daylight saving, the missed-slot catch-up and that it does not move the next slot, on-demand requests still overriding the hour, and the retired-interval migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9RFBA9rRN7CepQ8V11wau

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9RFBA9rRN7CepQ8V11wau)_